### PR TITLE
예외메세지 및 테스트 jacoco 설정

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/sh
+# pre-push hook: verify 태스크를 통과해야 push 가능
+
+echo "🔍 Running verify before push..."
+./gradlew verify --quiet
+
+if [ $? -ne 0 ]; then
+  echo "❌ verify failed. Push rejected."
+  exit 1
+fi
+
+echo "✅ verify passed. Pushing..."

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'org.springframework.boot' version '3.5.9'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '4.0.5'
+    id 'com.epages.restdocs-api-spec' version '0.19.2'
+    id 'org.ec4j.editorconfig' version '0.1.0'
+
+    id 'jacoco'
 }
 
 group = 'com.ujax'
@@ -19,7 +23,17 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+editorconfig {
+    excludes = ['build', '.gradle', 'out', 'node_modules']
+}
+check.dependsOn editorconfigCheck
 
 repositories {
     mavenCentral()
@@ -32,31 +46,188 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    runtimeOnly 'com.h2database:h2'
 
-    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 
     testCompileOnly "org.projectlombok:lombok"
     testAnnotationProcessor "org.projectlombok:lombok"
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:3.0.2'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.2'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 tasks.named('test') {
-    outputs.dir snippetsDir
     useJUnitPlatform()
+    //mokito 경고 무시
+    jvmArgs("-XX:+EnableDynamicAgentLoading",
+            "-Xshare:off"
+    )
+}
+
+//@Tag("restDocs")을 찾아서 문서화
+tasks.register("restDocsTest", Test) {
+    dependsOn tasks.named("test")
+    outputs.dir snippetsDir
+
+    useJUnitPlatform {
+        includeTags("restDocs")
+    }
+
+    finalizedBy "asciidoctor"
+    finalizedBy "openapi3"
 }
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
-    dependsOn test
+    configurations 'asciidoctorExt'
+    dependsOn tasks.named('test')
+    dependsOn tasks.named('restDocsTest')
 }
+
+openapi3 {
+    server = 'http://localhost:8080'
+    title = 'ujax API'
+    description = '백준 알고리즘 스터디 프로젝트 백엔드 API'
+    version = project.version.toString()
+    format = 'yaml'
+}
+
+
+bootJar {
+    dependsOn 'asciidoctor', 'openapi3'
+
+    from("swagger-ui") {
+        into "BOOT-INF/classes/static/swagger"
+    }
+
+    from("${asciidoctor.outputDir}") {
+        into 'BOOT-INF/classes/static/docs'
+    }
+
+    from(layout.buildDirectory.dir("api-spec")) {
+        into 'BOOT-INF/classes/static/swagger'
+    }
+}
+
+// git hooksPath 자동 설정 (clone 후 최초 빌드 시 자동 적용)
+tasks.register('installGitHooks') {
+    group = 'setup'
+    description = 'Set git hooksPath to .githooks'
+    doLast {
+        exec {
+            commandLine 'git', 'config', 'core.hooksPath', '.githooks'
+        }
+        logger.lifecycle('Git hooksPath set to .githooks')
+    }
+}
+compileJava.dependsOn installGitHooks
+
+// 한 방 검증 파이프라인(이름: verify)
+tasks.register('verify') {
+    group = 'verification'
+    description = 'Run editorconfig, checkstyle, unit tests, JaCoCo report & coverage verification'
+    dependsOn 'editorconfigCheck',
+            'test',
+            'jacocoTestReport',
+            'jacocoTestCoverageVerification'
+}
+
+//check 시 커버리지 검증 포함
+check {
+    dependsOn jacocoTestCoverageVerification
+}
+
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+// === JaCoCo 공통 exclude 패턴 ===
+def jacocoExcludes = [
+        '**/Q*',                 // QueryDSL
+        '**/*Application*',      // 메인 애플리케이션 클래스
+        '**/*Config*',           // 설정 클래스
+        '**/dto/**',             // DTO
+        '**/external/**',        // API Client
+        '**/global/**',          // global 패키지 전체
+]
+
+// 리포트 생성
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+        html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
+    }
+
+    // 리포트 대상 클래스에서 공통 exclude 적용
+    classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: jacocoExcludes)
+            })
+    )
+}
+
+// 커버리지 검증
+jacocoTestCoverageVerification {
+    dependsOn test
+
+    // 검증 대상 클래스에서도 동일하게 공통 exclude 적용
+    classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: jacocoExcludes)
+            })
+    )
+
+    violationRules {
+/*
+          rule {
+            element = 'CLASS'
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70    // 라인 커버리지 최소 70%
+            }
+        }
+*/
+/*
+        rule {
+            element = 'CLASS'
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.70    // 브랜치 커버리지 최소 70%
+            }
+        }
+*/
+        rule {
+            element = 'BUNDLE'
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70  // 전체 평균 70% 유지
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/ujax/global/exception/BusinessException.java
+++ b/src/main/java/com/ujax/global/exception/BusinessException.java
@@ -6,20 +6,57 @@ import lombok.Getter;
 public abstract class BusinessException extends RuntimeException {
 
 	private final ErrorCode errorCode;
+	private final Object[] args;
 
 	protected BusinessException(ErrorCode errorCode) {
 		super(errorCode.getDetail());
 		this.errorCode = errorCode;
+		this.args = new Object[]{};
 	}
 
 	protected BusinessException(ErrorCode errorCode, String message) {
 		super(message);
 		this.errorCode = errorCode;
+		this.args = new Object[]{};
 	}
 
-	/*
+	/**
+	 * 동적 메시지 포맷팅을 위한 생성자
+	 * 예: new SomeException(ErrorCode.USER_NOT_FOUND, "userId", 123)
+	 */
+	protected BusinessException(ErrorCode errorCode, Object... args) {
+		super(formatMessage(errorCode.getDetail(), args));
+		this.errorCode = errorCode;
+		this.args = args;
+	}
+
+	private static String formatMessage(String template, Object... args) {
+		if (args == null || args.length == 0) {
+			return template;
+		}
+		try {
+			return String.format(template.replace("{}", "%s"), args);
+		} catch (Exception e) {
+			return template;
+		}
+	}
+
+	/**
 	 * 이 예외를 로그로 남길지 여부
-	 * */
+	 */
 	public abstract boolean isNecessaryToLog();
 
+	/**
+	 * HTTP 상태 코드 반환
+	 */
+	public int getHttpStatus() {
+		return errorCode.getHttpStatus().value();
+	}
+
+	/**
+	 * 에러 코드 문자열 반환
+	 */
+	public String getCode() {
+		return errorCode.getCode();
+	}
 }

--- a/src/main/java/com/ujax/global/exception/ErrorCode.java
+++ b/src/main/java/com/ujax/global/exception/ErrorCode.java
@@ -9,13 +9,49 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	INVALID_INPUT(HttpStatus.BAD_REQUEST, "400", "잘못된 요청 형식 입니다."),
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "401", "잘못된 파라미터 형식 입니다."),
+	// ==================== 400 Bad Request ====================
+	INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청 형식입니다."),
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "잘못된 파라미터 형식입니다."),
+	MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "C003", "필수 입력값이 누락되었습니다."),
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "잘못된 타입의 값입니다."),
 
-	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 오류가 발생했습니다."),
+	// ==================== 401 Unauthorized ====================
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
+
+	// ==================== 403 Forbidden ====================
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "A010", "접근 권한이 없습니다."),
+	FORBIDDEN_RESOURCE(HttpStatus.FORBIDDEN, "A011", "해당 리소스에 대한 권한이 없습니다."),
+
+	// ==================== 404 Not Found ====================
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "요청한 리소스를 찾을 수 없습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "사용자를 찾을 수 없습니다."),
+
+	// ==================== 409 Conflict ====================
+	DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "D001", "이미 존재하는 리소스입니다."),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "D002", "이미 사용 중인 이메일입니다."),
+	RESOURCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "D003", "리소스가 이미 존재합니다."),
+
+	// ==================== 422 Unprocessable Entity ====================
+	UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "U001", "요청을 처리할 수 없습니다."),
+	BUSINESS_RULE_VIOLATION(HttpStatus.UNPROCESSABLE_ENTITY, "U002", "비즈니스 규칙 위반입니다."),
+
+	// ==================== 429 Too Many Requests ====================
+	TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "T001", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
+	// ==================== 500 Internal Server Error ====================
+	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 오류가 발생했습니다."),
+	DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S002", "데이터베이스 오류가 발생했습니다."),
+
+	// ==================== 502 Bad Gateway ====================
+	EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "E001", "외부 서비스 연동 중 오류가 발생했습니다."),
+
+	// ==================== 503 Service Unavailable ====================
+	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E002", "서비스를 일시적으로 사용할 수 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;
-	private final String title;
+	private final String code;
 	private final String detail;
 }

--- a/src/main/java/com/ujax/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ujax/global/exception/GlobalExceptionHandler.java
@@ -2,65 +2,236 @@ package com.ujax.global.exception;
 
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+	private static final String ERROR_DOC_URI = "/docs/index.html#error-code-list";
+
 	/**
 	 * [Exception] 비즈니스/도메인 예외
 	 */
 	@ExceptionHandler(BusinessException.class)
 	public ProblemDetail handle(BusinessException ex) {
-		if (ex.isNecessaryToLog()) {
-			log.error("[BusinessException] {}", ex.getMessage(), ex);
-		}
 		ErrorCode errorCode = ex.getErrorCode();
 
-		ProblemDetail problemDetail = ProblemDetail.forStatus(errorCode.getHttpStatus());
-		problemDetail.setType(URI.create("/docs/index.html#error-code-list"));
-		problemDetail.setTitle(errorCode.getTitle());
-		problemDetail.setDetail(ex.getMessage());
-		problemDetail.setProperty("exception", ex.getClass().getSimpleName());
-		problemDetail.setProperty("timestamp", LocalDateTime.now());
+		if (ex.isNecessaryToLog()) {
+			log.error("[BusinessException] code={}, message={}", errorCode.getCode(), ex.getMessage(), ex);
+		} else {
+			log.warn("[BusinessException] code={}, message={}", errorCode.getCode(), ex.getMessage());
+		}
 
-		log.warn("[BusinessException] code={}, message={}",
-			errorCode.getTitle(), ex.getMessage(), ex);
-
-		return problemDetail;
+		return createProblemDetail(
+			errorCode.getHttpStatus(),
+			errorCode.getCode(),
+			ex.getMessage(),
+			ex.getClass().getSimpleName()
+		);
 	}
 
 	/**
 	 * [Exception] @Valid, @RequestBody 검증 실패
-	 * */
+	 */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ProblemDetail handle(MethodArgumentNotValidException ex) {
-		return createProblemDetail(ex, ErrorCode.INVALID_INPUT);
+		List<FieldErrorDetail> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+			.map(error -> new FieldErrorDetail(
+				error.getField(),
+				error.getRejectedValue(),
+				error.getDefaultMessage()
+			))
+			.collect(Collectors.toList());
+
+		log.warn("[ValidationException] fieldErrors={}", fieldErrors);
+
+		ProblemDetail problemDetail = createProblemDetail(
+			HttpStatus.BAD_REQUEST,
+			ErrorCode.INVALID_INPUT.getCode(),
+			ErrorCode.INVALID_INPUT.getDetail(),
+			ex.getClass().getSimpleName()
+		);
+		problemDetail.setProperty("fieldErrors", fieldErrors);
+
+		return problemDetail;
+	}
+
+	/**
+	 * [Exception] @Validated 검증 실패 (Query Parameter, Path Variable)
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ProblemDetail handle(ConstraintViolationException ex) {
+		List<String> violations = ex.getConstraintViolations().stream()
+			.map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+			.collect(Collectors.toList());
+
+		log.warn("[ConstraintViolationException] violations={}", violations);
+
+		ProblemDetail problemDetail = createProblemDetail(
+			HttpStatus.BAD_REQUEST,
+			ErrorCode.INVALID_PARAMETER.getCode(),
+			ErrorCode.INVALID_PARAMETER.getDetail(),
+			ex.getClass().getSimpleName()
+		);
+		problemDetail.setProperty("violations", violations);
+
+		return problemDetail;
+	}
+
+	/**
+	 * [Exception] 요청 파라미터 누락
+	 */
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ProblemDetail handle(MissingServletRequestParameterException ex) {
+		String message = String.format("필수 파라미터 '%s'이(가) 누락되었습니다.", ex.getParameterName());
+		log.warn("[MissingParameterException] {}", message);
+
+		return createProblemDetail(
+			HttpStatus.BAD_REQUEST,
+			ErrorCode.MISSING_REQUIRED_FIELD.getCode(),
+			message,
+			ex.getClass().getSimpleName()
+		);
+	}
+
+	/**
+	 * [Exception] 타입 변환 실패
+	 */
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ProblemDetail handle(MethodArgumentTypeMismatchException ex) {
+		String message = String.format("파라미터 '%s'의 타입이 올바르지 않습니다. (기대 타입: %s)",
+			ex.getName(),
+			ex.getRequiredType() != null ? ex.getRequiredType().getSimpleName() : "unknown"
+		);
+		log.warn("[TypeMismatchException] {}", message);
+
+		return createProblemDetail(
+			HttpStatus.BAD_REQUEST,
+			ErrorCode.INVALID_TYPE_VALUE.getCode(),
+			message,
+			ex.getClass().getSimpleName()
+		);
+	}
+
+	/**
+	 * [Exception] JSON 파싱 실패
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ProblemDetail handle(HttpMessageNotReadableException ex) {
+		log.warn("[HttpMessageNotReadableException] {}", ex.getMessage());
+
+		return createProblemDetail(
+			HttpStatus.BAD_REQUEST,
+			ErrorCode.INVALID_INPUT.getCode(),
+			"요청 본문을 읽을 수 없습니다. JSON 형식을 확인해주세요.",
+			ex.getClass().getSimpleName()
+		);
+	}
+
+	/**
+	 * [Exception] 지원하지 않는 HTTP 메서드
+	 */
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ProblemDetail handle(HttpRequestMethodNotSupportedException ex) {
+		String message = String.format("지원하지 않는 HTTP 메서드입니다: %s", ex.getMethod());
+		log.warn("[MethodNotSupportedException] {}", message);
+
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.METHOD_NOT_ALLOWED);
+		problemDetail.setType(URI.create(ERROR_DOC_URI));
+		problemDetail.setTitle("METHOD_NOT_ALLOWED");
+		problemDetail.setDetail(message);
+		problemDetail.setProperty("exception", ex.getClass().getSimpleName());
+		problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+		return problemDetail;
+	}
+
+	/**
+	 * [Exception] 지원하지 않는 Media Type
+	 */
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public ProblemDetail handle(HttpMediaTypeNotSupportedException ex) {
+		String message = String.format("지원하지 않는 Content-Type입니다: %s", ex.getContentType());
+		log.warn("[MediaTypeNotSupportedException] {}", message);
+
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+		problemDetail.setType(URI.create(ERROR_DOC_URI));
+		problemDetail.setTitle("UNSUPPORTED_MEDIA_TYPE");
+		problemDetail.setDetail(message);
+		problemDetail.setProperty("exception", ex.getClass().getSimpleName());
+		problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+		return problemDetail;
+	}
+
+	/**
+	 * [Exception] 핸들러를 찾을 수 없음 (404)
+	 */
+	@ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+	public ProblemDetail handleNotFound(Exception ex) {
+		log.warn("[NotFoundException] {}", ex.getMessage());
+
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setType(URI.create(ERROR_DOC_URI));
+		problemDetail.setTitle("NOT_FOUND");
+		problemDetail.setDetail("요청한 리소스를 찾을 수 없습니다.");
+		problemDetail.setProperty("exception", ex.getClass().getSimpleName());
+		problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+		return problemDetail;
 	}
 
 	/**
 	 * [Exception] 예측하지 못한 모든 예외 처리
-	 * */
+	 */
 	@ExceptionHandler(Exception.class)
 	public ProblemDetail handle(Exception ex) {
-		return createProblemDetail(ex, ErrorCode.INTERNAL_ERROR);
+		log.error("[UnhandledException] ", ex);
+
+		return createProblemDetail(
+			HttpStatus.INTERNAL_SERVER_ERROR,
+			ErrorCode.INTERNAL_ERROR.getCode(),
+			ErrorCode.INTERNAL_ERROR.getDetail(),
+			ex.getClass().getSimpleName()
+		);
 	}
 
-	private ProblemDetail createProblemDetail(Exception ex, ErrorCode errorCode) {
-		ProblemDetail problemDetail = ProblemDetail.forStatus(errorCode.getHttpStatus());
-		problemDetail.setType(URI.create("/docs/index.html#error-code-list"));
-		problemDetail.setTitle(errorCode.getTitle());
-		problemDetail.setDetail(errorCode.getDetail());
-		problemDetail.setProperty("exception", ex.getClass().getSimpleName());
+	private ProblemDetail createProblemDetail(HttpStatus status, String code, String detail, String exceptionName) {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+		problemDetail.setType(URI.create(ERROR_DOC_URI));
+		problemDetail.setTitle(code);
+		problemDetail.setDetail(detail);
+		problemDetail.setProperty("exception", exceptionName);
 		problemDetail.setProperty("timestamp", LocalDateTime.now());
 		return problemDetail;
 	}
 
+	/**
+	 * 필드 에러 상세 정보
+	 */
+	public record FieldErrorDetail(
+		String field,
+		Object rejectedValue,
+		String message
+	) {
+	}
 }

--- a/src/main/java/com/ujax/global/exception/common/BadRequestException.java
+++ b/src/main/java/com/ujax/global/exception/common/BadRequestException.java
@@ -1,0 +1,31 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 400 Bad Request - 잘못된 요청인 경우
+ */
+public class BadRequestException extends BusinessException {
+
+	public BadRequestException() {
+		super(ErrorCode.INVALID_INPUT);
+	}
+
+	public BadRequestException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public BadRequestException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public BadRequestException(String message) {
+		super(ErrorCode.INVALID_INPUT, message);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return false;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/BusinessRuleViolationException.java
+++ b/src/main/java/com/ujax/global/exception/common/BusinessRuleViolationException.java
@@ -1,0 +1,31 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 422 Unprocessable Entity - 비즈니스 규칙 위반 시
+ */
+public class BusinessRuleViolationException extends BusinessException {
+
+	public BusinessRuleViolationException() {
+		super(ErrorCode.BUSINESS_RULE_VIOLATION);
+	}
+
+	public BusinessRuleViolationException(String message) {
+		super(ErrorCode.BUSINESS_RULE_VIOLATION, message);
+	}
+
+	public BusinessRuleViolationException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public BusinessRuleViolationException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return false;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/ConflictException.java
+++ b/src/main/java/com/ujax/global/exception/common/ConflictException.java
@@ -1,0 +1,42 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 409 Conflict - 리소스 충돌이 발생한 경우 (중복 등)
+ */
+public class ConflictException extends BusinessException {
+
+	public ConflictException() {
+		super(ErrorCode.DUPLICATE_RESOURCE);
+	}
+
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ConflictException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public ConflictException(String message) {
+		super(ErrorCode.DUPLICATE_RESOURCE, message);
+	}
+
+	/**
+	 * 중복 리소스 예외 생성
+	 * 예: ConflictException.duplicate("email", "test@example.com")
+	 */
+	public static ConflictException duplicate(String fieldName, Object value) {
+		return new ConflictException(
+			ErrorCode.DUPLICATE_RESOURCE,
+			String.format("이미 존재하는 %s입니다: %s", fieldName, value)
+		);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return false;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/ExternalApiException.java
+++ b/src/main/java/com/ujax/global/exception/common/ExternalApiException.java
@@ -1,0 +1,41 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 502 Bad Gateway - 외부 API 호출 실패 시
+ */
+public class ExternalApiException extends BusinessException {
+
+	private final String serviceName;
+
+	public ExternalApiException() {
+		super(ErrorCode.EXTERNAL_API_ERROR);
+		this.serviceName = "Unknown";
+	}
+
+	public ExternalApiException(String serviceName) {
+		super(ErrorCode.EXTERNAL_API_ERROR, serviceName + " 서비스 연동 중 오류가 발생했습니다.");
+		this.serviceName = serviceName;
+	}
+
+	public ExternalApiException(String serviceName, String message) {
+		super(ErrorCode.EXTERNAL_API_ERROR, message);
+		this.serviceName = serviceName;
+	}
+
+	public ExternalApiException(ErrorCode errorCode, String serviceName, String message) {
+		super(errorCode, message);
+		this.serviceName = serviceName;
+	}
+
+	public String getServiceName() {
+		return serviceName;
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return true;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/ForbiddenException.java
+++ b/src/main/java/com/ujax/global/exception/common/ForbiddenException.java
@@ -3,13 +3,25 @@ package com.ujax.global.exception.common;
 import com.ujax.global.exception.BusinessException;
 import com.ujax.global.exception.ErrorCode;
 
+/**
+ * 403 Forbidden - 접근 권한이 없는 경우
+ */
 public class ForbiddenException extends BusinessException {
+
+	public ForbiddenException() {
+		super(ErrorCode.ACCESS_DENIED);
+	}
+
 	public ForbiddenException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 
 	public ForbiddenException(ErrorCode errorCode, String message) {
 		super(errorCode, message);
+	}
+
+	public ForbiddenException(String message) {
+		super(ErrorCode.ACCESS_DENIED, message);
 	}
 
 	@Override

--- a/src/main/java/com/ujax/global/exception/common/InvalidParameterException.java
+++ b/src/main/java/com/ujax/global/exception/common/InvalidParameterException.java
@@ -3,13 +3,25 @@ package com.ujax.global.exception.common;
 import com.ujax.global.exception.BusinessException;
 import com.ujax.global.exception.ErrorCode;
 
+/**
+ * 400 Bad Request - 잘못된 파라미터인 경우
+ */
 public class InvalidParameterException extends BusinessException {
+
+	public InvalidParameterException() {
+		super(ErrorCode.INVALID_PARAMETER);
+	}
+
 	public InvalidParameterException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 
 	public InvalidParameterException(ErrorCode errorCode, String message) {
 		super(errorCode, message);
+	}
+
+	public InvalidParameterException(String message) {
+		super(ErrorCode.INVALID_PARAMETER, message);
 	}
 
 	@Override

--- a/src/main/java/com/ujax/global/exception/common/NotFoundException.java
+++ b/src/main/java/com/ujax/global/exception/common/NotFoundException.java
@@ -3,13 +3,36 @@ package com.ujax.global.exception.common;
 import com.ujax.global.exception.BusinessException;
 import com.ujax.global.exception.ErrorCode;
 
+/**
+ * 404 Not Found - 리소스를 찾을 수 없는 경우
+ */
 public class NotFoundException extends BusinessException {
+
+	public NotFoundException() {
+		super(ErrorCode.RESOURCE_NOT_FOUND);
+	}
+
 	public NotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 
 	public NotFoundException(ErrorCode errorCode, String message) {
 		super(errorCode, message);
+	}
+
+	public NotFoundException(String message) {
+		super(ErrorCode.RESOURCE_NOT_FOUND, message);
+	}
+
+	/**
+	 * 특정 엔티티를 찾을 수 없을 때 사용
+	 * 예: NotFoundException.of("User", userId)
+	 */
+	public static NotFoundException of(String entityName, Object id) {
+		return new NotFoundException(
+			ErrorCode.RESOURCE_NOT_FOUND,
+			String.format("%s(id=%s)를 찾을 수 없습니다.", entityName, id)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/ujax/global/exception/common/ServiceUnavailableException.java
+++ b/src/main/java/com/ujax/global/exception/common/ServiceUnavailableException.java
@@ -1,0 +1,31 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 503 Service Unavailable - 서비스를 사용할 수 없는 경우
+ */
+public class ServiceUnavailableException extends BusinessException {
+
+	public ServiceUnavailableException() {
+		super(ErrorCode.SERVICE_UNAVAILABLE);
+	}
+
+	public ServiceUnavailableException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ServiceUnavailableException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public ServiceUnavailableException(String message) {
+		super(ErrorCode.SERVICE_UNAVAILABLE, message);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return true;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/TooManyRequestsException.java
+++ b/src/main/java/com/ujax/global/exception/common/TooManyRequestsException.java
@@ -1,0 +1,31 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 429 Too Many Requests - 요청 제한 초과 시
+ */
+public class TooManyRequestsException extends BusinessException {
+
+	public TooManyRequestsException() {
+		super(ErrorCode.TOO_MANY_REQUESTS);
+	}
+
+	public TooManyRequestsException(String message) {
+		super(ErrorCode.TOO_MANY_REQUESTS, message);
+	}
+
+	public TooManyRequestsException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public TooManyRequestsException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return true;
+	}
+}

--- a/src/main/java/com/ujax/global/exception/common/UnauthorizedException.java
+++ b/src/main/java/com/ujax/global/exception/common/UnauthorizedException.java
@@ -1,0 +1,31 @@
+package com.ujax.global.exception.common;
+
+import com.ujax.global.exception.BusinessException;
+import com.ujax.global.exception.ErrorCode;
+
+/**
+ * 401 Unauthorized - 인증이 필요한 경우
+ */
+public class UnauthorizedException extends BusinessException {
+
+	public UnauthorizedException() {
+		super(ErrorCode.UNAUTHORIZED);
+	}
+
+	public UnauthorizedException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public UnauthorizedException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public UnauthorizedException(String message) {
+		super(ErrorCode.UNAUTHORIZED, message);
+	}
+
+	@Override
+	public boolean isNecessaryToLog() {
+		return false;
+	}
+}

--- a/src/main/java/com/ujax/global/response/ApiResponse.java
+++ b/src/main/java/com/ujax/global/response/ApiResponse.java
@@ -1,0 +1,49 @@
+package com.ujax.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * API 공통 응답 래퍼
+ * 성공 응답에 사용
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	private final boolean success;
+	private final T data;
+	private final String message;
+
+	/**
+	 * 데이터와 함께 성공 응답
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, data, null);
+	}
+
+	/**
+	 * 데이터와 메시지 함께 성공 응답
+	 */
+	public static <T> ApiResponse<T> success(T data, String message) {
+		return new ApiResponse<>(true, data, message);
+	}
+
+	/**
+	 * 데이터 없이 성공 응답
+	 */
+	public static ApiResponse<Void> success() {
+		return new ApiResponse<>(true, null, null);
+	}
+
+	/**
+	 * 메시지만 포함된 성공 응답
+	 */
+	public static ApiResponse<Void> successWithMessage(String message) {
+		return new ApiResponse<>(true, null, message);
+	}
+}

--- a/src/main/java/com/ujax/global/response/PageResponse.java
+++ b/src/main/java/com/ujax/global/response/PageResponse.java
@@ -1,0 +1,54 @@
+package com.ujax.global.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 페이지네이션 응답 래퍼
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PageResponse<T> {
+
+	private final List<T> content;
+	private final PageInfo page;
+
+	public static <T> PageResponse<T> of(List<T> content, int page, int size, long totalElements, int totalPages) {
+		return new PageResponse<>(content, new PageInfo(page, size, totalElements, totalPages));
+	}
+
+	public static <T> PageResponse<T> of(List<T> content, PageInfo pageInfo) {
+		return new PageResponse<>(content, pageInfo);
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class PageInfo {
+		private final int page;
+		private final int size;
+		private final long totalElements;
+		private final int totalPages;
+
+		public boolean hasNext() {
+			return page < totalPages - 1;
+		}
+
+		public boolean hasPrevious() {
+			return page > 0;
+		}
+
+		public boolean isFirst() {
+			return page == 0;
+		}
+
+		public boolean isLast() {
+			return page >= totalPages - 1;
+		}
+	}
+}

--- a/src/test/java/com/ujax/UjaxServerApplicationTests.java
+++ b/src/test/java/com/ujax/UjaxServerApplicationTests.java
@@ -2,8 +2,10 @@ package com.ujax;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class UjaxServerApplicationTests {
 
 	@Test


### PR DESCRIPTION
## PR 생성 정보

**Repository:** https://github.com/ujax-v2/server
**PR 생성 URL:** https://github.com/ujax-v2/server/compare/develop...feat/exceptionsetting?expand=1

---

### PR Title
```
Feat: 예외 처리 시스템 구축 및 Jacoco 테스트 커버리지 설정
```

---

### PR Body (아래 내용을 복사하세요)

# 관련 작업 / 이슈

> N/A (초기 프로젝트 설정)

---

## 내용 요약 (Description)
> 전역 예외 처리 시스템 구축 및 테스트/빌드 환경을 개선했습니다.

### 예외 처리 시스템
- **ErrorCode**: HTTP 상태별 에러 코드 체계화 (400, 401, 403, 404, 409, 422, 429, 500, 502, 503)
- **공통 예외 클래스 추가**:
  - `BadRequestException`, `InvalidParameterException` - 잘못된 요청
  - `UnauthorizedException`, `ForbiddenException` - 인증/인가
  - `NotFoundException` - 리소스 미존재
  - `ConflictException` - 중복 리소스
  - `BusinessRuleViolationException` - 비즈니스 규칙 위반
  - `TooManyRequestsException` - Rate Limiting
  - `ExternalApiException`, `ServiceUnavailableException` - 외부 서비스 오류
- **GlobalExceptionHandler**: 모든 예외 타입에 대한 핸들링 로직 강화

### 응답 표준화
- `ApiResponse<T>`: 성공 응답 래퍼
- `PageResponse<T>`: 페이징 응답 래퍼

### 빌드 및 테스트 환경
- **Jacoco**: 테스트 커버리지 측정 도구 추가
- **RestDocs API Spec**: OpenAPI 3.0 문서 자동 생성
- **EditorConfig**: 코드 스타일 일관성 유지
- **Pre-push Hook**: 푸시 전 검증 자동화

---

## 테스트
> 로컬 빌드 및 테스트 통과 확인

- `./gradlew build` 정상 실행
- 기존 테스트 통과 확인

---

## PR 체크리스트

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

- [ ] Yes (호환성 깨짐 있음)
- [x] No

---

## 로그 / 스크린샷 (선택)

N/A (백엔드 설정 작업)

---

## 기타 정보 / 의존성 (선택)

- **관련 TODO**: 도메인별 구체적인 예외 클래스 추가 필요 시 확장 예정
- **추후 리팩터링/성능 개선 포인트**: ErrorCode 메시지 다국어 지원 고려
- **다른 모듈/서비스와의 의존성 또는 영향**: 없음 (global 모듈 내 변경)
