### PR TITLE
Problem 도메인 구현 및 크롤링 인제스트 API 추가

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -32,6 +32,7 @@
 
 ## 테스트 스타일
 - `@Nested` + `@DisplayName`으로 기능별 그룹핑 (한글 DisplayName)
+- `@Nested` 안에 테스트가 1개뿐이면 `@Nested`를 사용하지 않고 flat 구조로 작성
 - `@DisplayName`에 구현 디테일(클래스명 등)을 넣지 않음 — 행위 중심으로 작성
   ```
   // Bad:  "존재하지 않는 유저를 조회하면 NotFoundException이 발생한다"

--- a/src/main/java/com/ujax/application/problem/ProblemService.java
+++ b/src/main/java/com/ujax/application/problem/ProblemService.java
@@ -1,0 +1,100 @@
+package com.ujax.application.problem;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ujax.application.problem.dto.response.ProblemResponse;
+import com.ujax.domain.problem.AlgorithmTag;
+import com.ujax.domain.problem.AlgorithmTagRepository;
+import com.ujax.domain.problem.Problem;
+import com.ujax.domain.problem.ProblemRepository;
+import com.ujax.domain.problem.Sample;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.ConflictException;
+import com.ujax.global.exception.common.NotFoundException;
+import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemService {
+
+	private final ProblemRepository problemRepository;
+	private final AlgorithmTagRepository algorithmTagRepository;
+
+	public ProblemResponse getProblem(Long problemId) {
+		return ProblemResponse.from(findProblemById(problemId));
+	}
+
+	public ProblemResponse getProblemByNumber(int problemNumber) {
+		Problem problem = problemRepository.findByProblemNumber(problemNumber)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND));
+		return ProblemResponse.from(problem);
+	}
+
+	@Transactional
+	public ProblemResponse createProblem(ProblemIngestRequest request) {
+		if (problemRepository.existsByProblemNumber(request.problemNumber())) {
+			throw new ConflictException(ErrorCode.DUPLICATE_PROBLEM);
+		}
+
+		Problem problem = Problem.create(
+			request.problemNumber(), cleanTitle(request.title()), request.tier(),
+			request.timeLimit(), request.memoryLimit(),
+			request.description(), request.inputDescription(), request.outputDescription(),
+			request.url()
+		);
+
+		addSamples(problem, request.samples());
+		linkAlgorithmTags(problem, request.tags());
+
+		problemRepository.save(problem);
+		return ProblemResponse.from(problem);
+	}
+
+	private void addSamples(Problem problem, List<ProblemIngestRequest.SampleDto> samples) {
+		if (samples == null) {
+			return;
+		}
+		for (ProblemIngestRequest.SampleDto s : samples) {
+			problem.addSample(Sample.create(s.sampleIndex(), s.input(), s.output()));
+		}
+	}
+
+	/** 기존 태그가 있으면 재사용하고, 없으면 새로 생성하여 연결 */
+	private void linkAlgorithmTags(Problem problem, List<ProblemIngestRequest.TagDto> tags) {
+		if (tags == null) {
+			return;
+		}
+		for (ProblemIngestRequest.TagDto t : tags) {
+			if (t.name() == null || t.name().isBlank()) {
+				continue;
+			}
+			AlgorithmTag tag = algorithmTagRepository.findByName(t.name())
+				.orElseGet(() -> algorithmTagRepository.save(AlgorithmTag.create(t.name())));
+			problem.addAlgorithmTag(tag);
+		}
+	}
+
+	private Problem findProblemById(Long problemId) {
+		return problemRepository.findById(problemId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND));
+	}
+
+	/** 크롤러에서 제목에 탭(티어 정보)·개행이 섞여 들어오는 경우를 정리 */
+	private String cleanTitle(String title) {
+		if (title == null) {
+			return null;
+		}
+		int tabIdx = title.indexOf('\t');
+		if (tabIdx >= 0) {
+			title = title.substring(0, tabIdx);
+		}
+		return title.replace('\r', ' ').replace('\n', ' ')
+			.replaceAll("\\s+", " ").trim();
+	}
+}

--- a/src/main/java/com/ujax/application/problem/dto/response/AlgorithmTagResponse.java
+++ b/src/main/java/com/ujax/application/problem/dto/response/AlgorithmTagResponse.java
@@ -1,0 +1,16 @@
+package com.ujax.application.problem.dto.response;
+
+import com.ujax.domain.problem.AlgorithmTag;
+
+public record AlgorithmTagResponse(
+	Long id,
+	String name
+) {
+
+	public static AlgorithmTagResponse from(AlgorithmTag tag) {
+		return new AlgorithmTagResponse(
+			tag.getId(),
+			tag.getName()
+		);
+	}
+}

--- a/src/main/java/com/ujax/application/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/com/ujax/application/problem/dto/response/ProblemResponse.java
@@ -1,0 +1,42 @@
+package com.ujax.application.problem.dto.response;
+
+import java.util.List;
+
+import com.ujax.domain.problem.Problem;
+
+public record ProblemResponse(
+	Long id,
+	int problemNumber,
+	String title,
+	String tier,
+	String timeLimit,
+	String memoryLimit,
+	String description,
+	String inputDescription,
+	String outputDescription,
+	String url,
+	List<SampleResponse> samples,
+	List<AlgorithmTagResponse> algorithmTags
+) {
+
+	public static ProblemResponse from(Problem problem) {
+		return new ProblemResponse(
+			problem.getId(),
+			problem.getProblemNumber(),
+			problem.getTitle(),
+			problem.getTier(),
+			problem.getTimeLimit(),
+			problem.getMemoryLimit(),
+			problem.getDescription(),
+			problem.getInputDescription(),
+			problem.getOutputDescription(),
+			problem.getUrl(),
+			problem.getSamples().stream()
+				.map(SampleResponse::from)
+				.toList(),
+			problem.getAlgorithmTags().stream()
+				.map(AlgorithmTagResponse::from)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/com/ujax/application/problem/dto/response/SampleResponse.java
+++ b/src/main/java/com/ujax/application/problem/dto/response/SampleResponse.java
@@ -1,0 +1,20 @@
+package com.ujax.application.problem.dto.response;
+
+import com.ujax.domain.problem.Sample;
+
+public record SampleResponse(
+	Long id,
+	int sampleIndex,
+	String input,
+	String output
+) {
+
+	public static SampleResponse from(Sample sample) {
+		return new SampleResponse(
+			sample.getId(),
+			sample.getSampleIndex(),
+			sample.getInput(),
+			sample.getOutput()
+		);
+	}
+}

--- a/src/main/java/com/ujax/domain/problem/AlgorithmTag.java
+++ b/src/main/java/com/ujax/domain/problem/AlgorithmTag.java
@@ -1,0 +1,41 @@
+package com.ujax.domain.problem;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+import com.ujax.domain.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "algorithm_tag")
+@Filter(
+	name = "softDeleteFilter",
+	condition = "deleted_at IS NULL"
+)
+@SQLDelete(sql = "UPDATE algorithm_tag SET deleted_at = now() WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlgorithmTag extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String name;
+
+	public static AlgorithmTag create(String name) {
+		AlgorithmTag tag = new AlgorithmTag();
+		tag.name = name;
+		return tag;
+	}
+}

--- a/src/main/java/com/ujax/domain/problem/AlgorithmTagRepository.java
+++ b/src/main/java/com/ujax/domain/problem/AlgorithmTagRepository.java
@@ -1,0 +1,10 @@
+package com.ujax.domain.problem;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlgorithmTagRepository extends JpaRepository<AlgorithmTag, Long> {
+
+	Optional<AlgorithmTag> findByName(String name);
+}

--- a/src/main/java/com/ujax/domain/problem/Problem.java
+++ b/src/main/java/com/ujax/domain/problem/Problem.java
@@ -1,0 +1,113 @@
+package com.ujax.domain.problem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+import com.ujax.domain.common.BaseEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "problem")
+@Filter(
+	name = "softDeleteFilter",
+	condition = "deleted_at IS NULL"
+)
+@SQLDelete(sql = "UPDATE problem SET deleted_at = now() WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Problem extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private int problemNumber;
+
+	@Column(nullable = false)
+	private String title;
+
+	private String tier;
+
+	private String timeLimit;
+
+	private String memoryLimit;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	@Column(columnDefinition = "TEXT")
+	private String inputDescription;
+
+	@Column(columnDefinition = "TEXT")
+	private String outputDescription;
+
+	private String url;
+
+	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Sample> samples = new ArrayList<>();
+
+	@ManyToMany
+	@JoinTable(
+		name = "problem_algorithm",
+		joinColumns = @JoinColumn(name = "problem_id"),
+		inverseJoinColumns = @JoinColumn(name = "algorithm_id")
+	)
+	private List<AlgorithmTag> algorithmTags = new ArrayList<>();
+
+	@Builder
+	private Problem(int problemNumber, String title, String tier, String timeLimit, String memoryLimit,
+		String description, String inputDescription, String outputDescription, String url) {
+		this.problemNumber = problemNumber;
+		this.title = title;
+		this.tier = tier;
+		this.timeLimit = timeLimit;
+		this.memoryLimit = memoryLimit;
+		this.description = description;
+		this.inputDescription = inputDescription;
+		this.outputDescription = outputDescription;
+		this.url = url;
+	}
+
+	public static Problem create(int problemNumber, String title, String tier, String timeLimit,
+		String memoryLimit, String description, String inputDescription, String outputDescription, String url) {
+		return Problem.builder()
+			.problemNumber(problemNumber)
+			.title(title)
+			.tier(tier)
+			.timeLimit(timeLimit)
+			.memoryLimit(memoryLimit)
+			.description(description)
+			.inputDescription(inputDescription)
+			.outputDescription(outputDescription)
+			.url(url)
+			.build();
+	}
+
+	public void addSample(Sample sample) {
+		this.samples.add(sample);
+		sample.assignProblem(this);
+	}
+
+	public void addAlgorithmTag(AlgorithmTag algorithmTag) {
+		this.algorithmTags.add(algorithmTag);
+	}
+}

--- a/src/main/java/com/ujax/domain/problem/ProblemRepository.java
+++ b/src/main/java/com/ujax/domain/problem/ProblemRepository.java
@@ -1,0 +1,21 @@
+package com.ujax.domain.problem;
+
+import java.util.Optional;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+	/** findById를 JPQL로 오버라이드하여 @Filter(softDeleteFilter) 적용 */
+	@Override
+	@NonNull
+	@Query("SELECT p FROM Problem p WHERE p.id = :id")
+	Optional<Problem> findById(@Param("id") @NonNull Long id);
+
+	Optional<Problem> findByProblemNumber(int problemNumber);
+
+	boolean existsByProblemNumber(int problemNumber);
+}

--- a/src/main/java/com/ujax/domain/problem/Sample.java
+++ b/src/main/java/com/ujax/domain/problem/Sample.java
@@ -1,0 +1,64 @@
+package com.ujax.domain.problem;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+import com.ujax.domain.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "sample",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"problem_id", "sample_index"})
+)
+@Filter(
+	name = "softDeleteFilter",
+	condition = "deleted_at IS NULL"
+)
+@SQLDelete(sql = "UPDATE sample SET deleted_at = now() WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sample extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "problem_id", nullable = false)
+	private Problem problem;
+
+	@Column(nullable = false)
+	private int sampleIndex;
+
+	@Column(columnDefinition = "TEXT")
+	private String input;
+
+	@Column(columnDefinition = "TEXT")
+	private String output;
+
+	public static Sample create(int sampleIndex, String input, String output) {
+		Sample sample = new Sample();
+		sample.sampleIndex = sampleIndex;
+		sample.input = input;
+		sample.output = output;
+		return sample;
+	}
+
+	void assignProblem(Problem problem) {
+		this.problem = problem;
+	}
+}

--- a/src/main/java/com/ujax/domain/problem/SampleRepository.java
+++ b/src/main/java/com/ujax/domain/problem/SampleRepository.java
@@ -1,0 +1,6 @@
+package com.ujax.domain.problem;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SampleRepository extends JpaRepository<Sample, Long> {
+}

--- a/src/main/java/com/ujax/global/exception/ErrorCode.java
+++ b/src/main/java/com/ujax/global/exception/ErrorCode.java
@@ -29,12 +29,14 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "사용자를 찾을 수 없습니다."),
 	WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "R003", "워크스페이스를 찾을 수 없습니다."),
 	WORKSPACE_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "R004", "워크스페이스 멤버를 찾을 수 없습니다."),
+	PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "R005", "문제를 찾을 수 없습니다."),
 
 	// ==================== 409 Conflict ====================
 	DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "D001", "이미 존재하는 리소스입니다."),
 	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "D002", "이미 사용 중인 이메일입니다."),
 	RESOURCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "D003", "리소스가 이미 존재합니다."),
 	ALREADY_WORKSPACE_MEMBER(HttpStatus.CONFLICT, "D004", "이미 워크스페이스에 가입된 멤버입니다."),
+	DUPLICATE_PROBLEM(HttpStatus.CONFLICT, "D005", "이미 등록된 문제 번호입니다."),
 
 	// ==================== 422 Unprocessable Entity ====================
 	UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "U001", "요청을 처리할 수 없습니다."),

--- a/src/main/java/com/ujax/infrastructure/web/problem/ProblemController.java
+++ b/src/main/java/com/ujax/infrastructure/web/problem/ProblemController.java
@@ -1,0 +1,40 @@
+package com.ujax.infrastructure.web.problem;
+
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ujax.application.problem.ProblemService;
+import com.ujax.application.problem.dto.response.ProblemResponse;
+import com.ujax.global.dto.ApiResponse;
+import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/problems")
+@RequiredArgsConstructor
+public class ProblemController {
+
+	private final ProblemService problemService;
+
+	@GetMapping("/{problemId}")
+	public ApiResponse<ProblemResponse> getProblem(@PathVariable Long problemId) {
+		return ApiResponse.success(problemService.getProblem(problemId));
+	}
+
+	@GetMapping("/number/{problemNumber}")
+	public ApiResponse<ProblemResponse> getProblemByNumber(@PathVariable int problemNumber) {
+		return ApiResponse.success(problemService.getProblemByNumber(problemNumber));
+	}
+
+	@PostMapping("/ingest")
+	public ApiResponse<ProblemResponse> ingestProblem(@Valid @RequestBody ProblemIngestRequest request) {
+		return ApiResponse.success(problemService.createProblem(request));
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/web/problem/dto/request/ProblemIngestRequest.java
+++ b/src/main/java/com/ujax/infrastructure/web/problem/dto/request/ProblemIngestRequest.java
@@ -1,0 +1,31 @@
+package com.ujax.infrastructure.web.problem.dto.request;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProblemIngestRequest(
+	@Positive @JsonProperty("problemNum") int problemNumber,
+	@NotBlank String title,
+	String tier,
+	String timeLimit,
+	String memoryLimit,
+	@JsonProperty("problemDesc") String description,
+	@JsonProperty("problemInput") String inputDescription,
+	@JsonProperty("problemOutput") String outputDescription,
+	String url,
+	List<SampleDto> samples,
+	List<TagDto> tags
+) {
+
+	public record SampleDto(int sampleIndex, String input, String output) {
+	}
+
+	public record TagDto(String name) {
+	}
+}

--- a/src/test/java/com/ujax/application/problem/ProblemServiceTest.java
+++ b/src/test/java/com/ujax/application/problem/ProblemServiceTest.java
@@ -1,0 +1,223 @@
+package com.ujax.application.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.application.problem.dto.response.ProblemResponse;
+import com.ujax.domain.problem.AlgorithmTagRepository;
+import com.ujax.domain.problem.Problem;
+import com.ujax.domain.problem.ProblemRepository;
+import com.ujax.domain.problem.Sample;
+import com.ujax.global.exception.common.ConflictException;
+import com.ujax.global.exception.common.NotFoundException;
+import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ProblemServiceTest {
+
+	@Autowired
+	private ProblemService problemService;
+
+	@Autowired
+	private ProblemRepository problemRepository;
+
+	@Autowired
+	private AlgorithmTagRepository algorithmTagRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("DELETE FROM problem_algorithm");
+		jdbcTemplate.execute("DELETE FROM sample");
+		problemRepository.deleteAllInBatch();
+		algorithmTagRepository.deleteAllInBatch();
+	}
+
+	@Nested
+	@DisplayName("문제 조회")
+	class GetProblem {
+
+		@Test
+		@DisplayName("ID로 문제를 조회한다")
+		void getProblem_Success() {
+			// given
+			Problem problem = problemRepository.save(Problem.create(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				"설명", "입력", "출력", "https://www.acmicpc.net/problem/1000"
+			));
+
+			// when
+			ProblemResponse response = problemService.getProblem(problem.getId());
+
+			// then
+			assertThat(response).extracting("problemNumber", "title", "tier")
+				.containsExactly(1000, "A+B", "Bronze V");
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 문제를 조회하면 오류가 발생한다")
+		void getProblem_NotFound() {
+			// when & then
+			assertThatThrownBy(() -> problemService.getProblem(999L))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("문제 번호로 조회")
+	class GetProblemByNumber {
+
+		@Test
+		@DisplayName("문제 번호로 문제를 조회한다")
+		void getProblemByNumber_Success() {
+			// given
+			problemRepository.save(Problem.create(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				"설명", "입력", "출력", null
+			));
+
+			// when
+			ProblemResponse response = problemService.getProblemByNumber(1000);
+
+			// then
+			assertThat(response).extracting("problemNumber", "title")
+				.containsExactly(1000, "A+B");
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 문제 번호로 조회하면 오류가 발생한다")
+		void getProblemByNumber_NotFound() {
+			// when & then
+			assertThatThrownBy(() -> problemService.getProblemByNumber(9999))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("문제 생성")
+	class CreateProblem {
+
+		@Test
+		@DisplayName("문제를 생성한다")
+		void createProblem_Success() {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				"두 정수 A와 B를 입력받은 다음...",
+				"첫째 줄에 A와 B가 주어진다.",
+				"첫째 줄에 A+B를 출력한다.",
+				"https://www.acmicpc.net/problem/1000",
+				List.of(
+					new ProblemIngestRequest.SampleDto(1, "1 2", "3"),
+					new ProblemIngestRequest.SampleDto(2, "3 4", "7")
+				),
+				List.of(
+					new ProblemIngestRequest.TagDto("수학"),
+					new ProblemIngestRequest.TagDto("구현")
+				)
+			);
+
+			// when
+			ProblemResponse response = problemService.createProblem(request);
+
+			// then
+			assertThat(response).extracting("problemNumber", "title", "tier")
+				.containsExactly(1000, "A+B", "Bronze V");
+			assertThat(response.samples()).hasSize(2);
+			assertThat(response.algorithmTags()).hasSize(2)
+				.extracting("name")
+				.containsExactlyInAnyOrder("수학", "구현");
+		}
+
+		@Test
+		@DisplayName("입출력 예제와 태그 없이 문제를 생성한다")
+		void createProblem_WithoutSamplesAndTags() {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				"설명", "입력", "출력", null,
+				null, null
+			);
+
+			// when
+			ProblemResponse response = problemService.createProblem(request);
+
+			// then
+			assertThat(response.problemNumber()).isEqualTo(1000);
+			assertThat(response.samples()).isEmpty();
+			assertThat(response.algorithmTags()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("이미 존재하는 문제 번호로 생성하면 오류가 발생한다")
+		void createProblem_Duplicate() {
+			// given
+			problemRepository.save(Problem.create(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				null, null, null, null
+			));
+
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				null, null, null, null, null, null
+			);
+
+			// when & then
+			assertThatThrownBy(() -> problemService.createProblem(request))
+				.isInstanceOf(ConflictException.class);
+		}
+
+		@Test
+		@DisplayName("제목의 탭과 개행이 정리된다")
+		void createProblem_CleanTitle() {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "A+B\tBronze V", "Bronze V", "2 초", "128 MB",
+				null, null, null, null, null, null
+			);
+
+			// when
+			ProblemResponse response = problemService.createProblem(request);
+
+			// then
+			assertThat(response.title()).isEqualTo("A+B");
+		}
+
+		@Test
+		@DisplayName("같은 태그 이름이 이미 존재하면 재사용한다")
+		void createProblem_ReuseExistingTag() {
+			// given
+			ProblemIngestRequest request1 = new ProblemIngestRequest(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				null, null, null, null, null,
+				List.of(new ProblemIngestRequest.TagDto("수학"))
+			);
+			problemService.createProblem(request1);
+
+			ProblemIngestRequest request2 = new ProblemIngestRequest(
+				1001, "A-B", "Bronze V", "2 초", "128 MB",
+				null, null, null, null, null,
+				List.of(new ProblemIngestRequest.TagDto("수학"))
+			);
+
+			// when
+			problemService.createProblem(request2);
+
+			// then
+			assertThat(algorithmTagRepository.findAll()).hasSize(1);
+		}
+	}
+}

--- a/src/test/java/com/ujax/domain/problem/AlgorithmTagRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/problem/AlgorithmTagRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.ujax.domain.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class AlgorithmTagRepositoryTest {
+
+	@Autowired
+	private AlgorithmTagRepository algorithmTagRepository;
+
+	@BeforeEach
+	void setUp() {
+		algorithmTagRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("이름으로 알고리즘 태그를 조회한다")
+	void findByName() {
+		// given
+		algorithmTagRepository.save(AlgorithmTag.create("다이나믹 프로그래밍"));
+
+		// when
+		var found = algorithmTagRepository.findByName("다이나믹 프로그래밍");
+
+		// then
+		assertThat(found).isPresent();
+		assertThat(found.get().getName()).isEqualTo("다이나믹 프로그래밍");
+	}
+
+	@Test
+	@DisplayName("알고리즘 태그를 저장한다")
+	void save() {
+		// given
+		AlgorithmTag tag = AlgorithmTag.create("그래프 탐색");
+
+		// when
+		AlgorithmTag saved = algorithmTagRepository.save(tag);
+
+		// then
+		assertThat(saved.getId()).isNotNull();
+		assertThat(saved.getName()).isEqualTo("그래프 탐색");
+	}
+}

--- a/src/test/java/com/ujax/domain/problem/AlgorithmTagTest.java
+++ b/src/test/java/com/ujax/domain/problem/AlgorithmTagTest.java
@@ -1,0 +1,19 @@
+package com.ujax.domain.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AlgorithmTagTest {
+
+	@Test
+	@DisplayName("알고리즘 태그를 생성한다")
+	void createAlgorithmTag() {
+		// when
+		AlgorithmTag tag = AlgorithmTag.create("다이나믹 프로그래밍");
+
+		// then
+		assertThat(tag.getName()).isEqualTo("다이나믹 프로그래밍");
+	}
+}

--- a/src/test/java/com/ujax/domain/problem/ProblemRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/problem/ProblemRepositoryTest.java
@@ -1,0 +1,115 @@
+package com.ujax.domain.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class ProblemRepositoryTest {
+
+	@Autowired
+	private ProblemRepository problemRepository;
+
+	@Autowired
+	private AlgorithmTagRepository algorithmTagRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("DELETE FROM problem_algorithm");
+		jdbcTemplate.execute("DELETE FROM sample");
+		problemRepository.deleteAllInBatch();
+		algorithmTagRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("문제 번호로 문제를 조회한다")
+	void findByProblemNumber() {
+		// given
+		problemRepository.save(Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			"설명", "입력", "출력", "https://www.acmicpc.net/problem/1000"
+		));
+
+		// when
+		var found = problemRepository.findByProblemNumber(1000);
+
+		// then
+		assertThat(found).isPresent();
+		assertThat(found.get()).extracting("problemNumber", "title", "tier")
+			.containsExactly(1000, "A+B", "Bronze V");
+	}
+
+	@Test
+	@DisplayName("문제 번호 존재 여부를 확인한다")
+	void existsByProblemNumber() {
+		// given
+		problemRepository.save(Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			null, null, null, null
+		));
+
+		// when & then
+		assertThat(problemRepository.existsByProblemNumber(1000)).isTrue();
+	}
+
+	@Test
+	@DisplayName("문제를 입출력 예제와 함께 저장한다")
+	void saveWithSamples() {
+		// given
+		Problem problem = Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			null, null, null, null
+		);
+		problem.addSample(Sample.create(1, "1 2", "3"));
+		problem.addSample(Sample.create(2, "3 4", "7"));
+
+		// when
+		Problem saved = problemRepository.save(problem);
+
+		// then
+		assertThat(saved.getId()).isNotNull();
+		assertThat(saved.getSamples()).hasSize(2)
+			.extracting("sampleIndex", "input", "output")
+			.containsExactlyInAnyOrder(
+				tuple(1, "1 2", "3"),
+				tuple(2, "3 4", "7")
+			);
+	}
+
+	@Test
+	@DisplayName("문제를 알고리즘 태그와 함께 저장한다")
+	void saveWithAlgorithmTags() {
+		// given
+		AlgorithmTag tag1 = algorithmTagRepository.save(AlgorithmTag.create("수학"));
+		AlgorithmTag tag2 = algorithmTagRepository.save(AlgorithmTag.create("구현"));
+
+		Problem problem = Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			null, null, null, null
+		);
+		problem.addAlgorithmTag(tag1);
+		problem.addAlgorithmTag(tag2);
+
+		// when
+		Problem saved = problemRepository.save(problem);
+
+		// then
+		assertThat(saved.getAlgorithmTags()).hasSize(2)
+			.extracting("name")
+			.containsExactlyInAnyOrder("수학", "구현");
+	}
+}

--- a/src/test/java/com/ujax/domain/problem/ProblemTest.java
+++ b/src/test/java/com/ujax/domain/problem/ProblemTest.java
@@ -1,0 +1,65 @@
+package com.ujax.domain.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProblemTest {
+
+	@Test
+	@DisplayName("문제를 생성한다")
+	void createProblem() {
+		// when
+		Problem problem = Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			"두 정수 A와 B를 입력받은 다음...", "첫째 줄에 A와 B가 주어진다.",
+			"첫째 줄에 A+B를 출력한다.", "https://www.acmicpc.net/problem/1000"
+		);
+
+		// then
+		assertThat(problem).extracting(
+			"problemNumber", "title", "tier", "timeLimit", "memoryLimit", "url"
+		).containsExactly(
+			1000, "A+B", "Bronze V", "2 초", "128 MB", "https://www.acmicpc.net/problem/1000"
+		);
+	}
+
+	@Test
+	@DisplayName("문제에 입출력 예제를 추가한다")
+	void addSample() {
+		// given
+		Problem problem = Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			null, null, null, null
+		);
+		Sample sample = Sample.create(1, "1 2", "3");
+
+		// when
+		problem.addSample(sample);
+
+		// then
+		assertThat(problem.getSamples()).hasSize(1);
+		assertThat(problem.getSamples().getFirst()).extracting("sampleIndex", "input", "output")
+			.containsExactly(1, "1 2", "3");
+		assertThat(sample.getProblem()).isEqualTo(problem);
+	}
+
+	@Test
+	@DisplayName("문제에 알고리즘 태그를 추가한다")
+	void addAlgorithmTag() {
+		// given
+		Problem problem = Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			null, null, null, null
+		);
+		AlgorithmTag tag = AlgorithmTag.create("수학");
+
+		// when
+		problem.addAlgorithmTag(tag);
+
+		// then
+		assertThat(problem.getAlgorithmTags()).hasSize(1);
+		assertThat(problem.getAlgorithmTags().getFirst().getName()).isEqualTo("수학");
+	}
+}

--- a/src/test/java/com/ujax/domain/problem/SampleTest.java
+++ b/src/test/java/com/ujax/domain/problem/SampleTest.java
@@ -1,0 +1,20 @@
+package com.ujax.domain.problem;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SampleTest {
+
+	@Test
+	@DisplayName("입출력 예제를 생성한다")
+	void createSample() {
+		// when
+		Sample sample = Sample.create(1, "1 2", "3");
+
+		// then
+		assertThat(sample).extracting("sampleIndex", "input", "output")
+			.containsExactly(1, "1 2", "3");
+	}
+}

--- a/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerDocsTest.java
@@ -1,0 +1,256 @@
+package com.ujax.infrastructure.web.api.problem;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ujax.application.problem.ProblemService;
+import com.ujax.application.problem.dto.response.AlgorithmTagResponse;
+import com.ujax.application.problem.dto.response.ProblemResponse;
+import com.ujax.application.problem.dto.response.SampleResponse;
+import com.ujax.infrastructure.web.problem.ProblemController;
+import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+
+@Tag("restDocs")
+@WebMvcTest(ProblemController.class)
+@AutoConfigureRestDocs
+class ProblemControllerDocsTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ProblemService problemService;
+
+	private ProblemResponse createMockResponse() {
+		return new ProblemResponse(
+			1L, 1000, "A+B", "Bronze V", "2 초", "128 MB",
+			"두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+			"첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+			"첫째 줄에 A+B를 출력한다.",
+			"https://www.acmicpc.net/problem/1000",
+			List.of(
+				new SampleResponse(1L, 1, "1 2", "3"),
+				new SampleResponse(2L, 2, "3 4", "7")
+			),
+			List.of(
+				new AlgorithmTagResponse(1L, "수학"),
+				new AlgorithmTagResponse(2L, "구현")
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("문제 조회 API")
+	void getProblem() throws Exception {
+		// given
+		given(problemService.getProblem(1L)).willReturn(createMockResponse());
+
+		// when & then
+		mockMvc.perform(get("/api/v1/problems/{problemId}", 1L)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.problemNumber").value(1000))
+			.andDo(document("problem-get",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Problem")
+					.summary("문제 조회")
+					.description("문제 ID로 문제를 조회합니다")
+					.pathParameters(
+						parameterWithName("problemId").description("문제 ID")
+					)
+					.responseSchema(Schema.schema("ApiResponse-ProblemResponse"))
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("문제 ID"),
+						fieldWithPath("data.problemNumber").type(JsonFieldType.NUMBER).description("백준 문제 번호"),
+						fieldWithPath("data.title").type(JsonFieldType.STRING).description("문제 제목"),
+						fieldWithPath("data.tier").type(JsonFieldType.STRING).description("난이도").optional(),
+						fieldWithPath("data.timeLimit").type(JsonFieldType.STRING).description("시간 제한").optional(),
+						fieldWithPath("data.memoryLimit").type(JsonFieldType.STRING).description("메모리 제한").optional(),
+						fieldWithPath("data.description").type(JsonFieldType.STRING).description("문제 설명").optional(),
+						fieldWithPath("data.inputDescription").type(JsonFieldType.STRING).description("입력 설명").optional(),
+						fieldWithPath("data.outputDescription").type(JsonFieldType.STRING).description("출력 설명").optional(),
+						fieldWithPath("data.url").type(JsonFieldType.STRING).description("백준 문제 URL").optional(),
+						fieldWithPath("data.samples").type(JsonFieldType.ARRAY).description("입출력 예제 목록"),
+						fieldWithPath("data.samples[].id").type(JsonFieldType.NUMBER).description("예제 ID"),
+						fieldWithPath("data.samples[].sampleIndex").type(JsonFieldType.NUMBER).description("예제 번호"),
+						fieldWithPath("data.samples[].input").type(JsonFieldType.STRING).description("예제 입력").optional(),
+						fieldWithPath("data.samples[].output").type(JsonFieldType.STRING).description("예제 출력").optional(),
+						fieldWithPath("data.algorithmTags").type(JsonFieldType.ARRAY).description("알고리즘 태그 목록"),
+						fieldWithPath("data.algorithmTags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+						fieldWithPath("data.algorithmTags[].name").type(JsonFieldType.STRING).description("태그 이름"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("문제 번호로 조회 API")
+	void getProblemByNumber() throws Exception {
+		// given
+		given(problemService.getProblemByNumber(1000)).willReturn(createMockResponse());
+
+		// when & then
+		mockMvc.perform(get("/api/v1/problems/number/{problemNumber}", 1000)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.problemNumber").value(1000))
+			.andDo(document("problem-get-by-number",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Problem")
+					.summary("문제 번호로 조회")
+					.description("백준 문제 번호로 문제를 조회합니다")
+					.pathParameters(
+						parameterWithName("problemNumber").description("백준 문제 번호")
+					)
+					.responseSchema(Schema.schema("ApiResponse-ProblemResponse"))
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("문제 ID"),
+						fieldWithPath("data.problemNumber").type(JsonFieldType.NUMBER).description("백준 문제 번호"),
+						fieldWithPath("data.title").type(JsonFieldType.STRING).description("문제 제목"),
+						fieldWithPath("data.tier").type(JsonFieldType.STRING).description("난이도").optional(),
+						fieldWithPath("data.timeLimit").type(JsonFieldType.STRING).description("시간 제한").optional(),
+						fieldWithPath("data.memoryLimit").type(JsonFieldType.STRING).description("메모리 제한").optional(),
+						fieldWithPath("data.description").type(JsonFieldType.STRING).description("문제 설명").optional(),
+						fieldWithPath("data.inputDescription").type(JsonFieldType.STRING).description("입력 설명").optional(),
+						fieldWithPath("data.outputDescription").type(JsonFieldType.STRING).description("출력 설명").optional(),
+						fieldWithPath("data.url").type(JsonFieldType.STRING).description("백준 문제 URL").optional(),
+						fieldWithPath("data.samples").type(JsonFieldType.ARRAY).description("입출력 예제 목록"),
+						fieldWithPath("data.samples[].id").type(JsonFieldType.NUMBER).description("예제 ID"),
+						fieldWithPath("data.samples[].sampleIndex").type(JsonFieldType.NUMBER).description("예제 번호"),
+						fieldWithPath("data.samples[].input").type(JsonFieldType.STRING).description("예제 입력").optional(),
+						fieldWithPath("data.samples[].output").type(JsonFieldType.STRING).description("예제 출력").optional(),
+						fieldWithPath("data.algorithmTags").type(JsonFieldType.ARRAY).description("알고리즘 태그 목록"),
+						fieldWithPath("data.algorithmTags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+						fieldWithPath("data.algorithmTags[].name").type(JsonFieldType.STRING).description("태그 이름"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("문제 등록 API")
+	void ingestProblem() throws Exception {
+		// given
+		ProblemIngestRequest request = new ProblemIngestRequest(
+			1000, "A+B", "Bronze V", "2 초", "128 MB",
+			"두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+			"첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+			"첫째 줄에 A+B를 출력한다.",
+			"https://www.acmicpc.net/problem/1000",
+			List.of(
+				new ProblemIngestRequest.SampleDto(1, "1 2", "3"),
+				new ProblemIngestRequest.SampleDto(2, "3 4", "7")
+			),
+			List.of(
+				new ProblemIngestRequest.TagDto("수학"),
+				new ProblemIngestRequest.TagDto("구현")
+			)
+		);
+		given(problemService.createProblem(any(ProblemIngestRequest.class)))
+			.willReturn(createMockResponse());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/problems/ingest")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.problemNumber").value(1000))
+			.andDo(document("problem-ingest",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Problem")
+					.summary("문제 등록")
+					.description("크롤러에서 수집한 백준 문제를 등록합니다")
+					.requestSchema(Schema.schema("ProblemIngestRequest"))
+					.responseSchema(Schema.schema("ApiResponse-ProblemResponse"))
+					.requestFields(
+						fieldWithPath("problemNum").type(JsonFieldType.NUMBER).description("백준 문제 번호"),
+						fieldWithPath("title").type(JsonFieldType.STRING).description("문제 제목"),
+						fieldWithPath("tier").type(JsonFieldType.STRING).description("난이도").optional(),
+						fieldWithPath("timeLimit").type(JsonFieldType.STRING).description("시간 제한").optional(),
+						fieldWithPath("memoryLimit").type(JsonFieldType.STRING).description("메모리 제한").optional(),
+						fieldWithPath("problemDesc").type(JsonFieldType.STRING).description("문제 설명").optional(),
+						fieldWithPath("problemInput").type(JsonFieldType.STRING).description("입력 설명").optional(),
+						fieldWithPath("problemOutput").type(JsonFieldType.STRING).description("출력 설명").optional(),
+						fieldWithPath("url").type(JsonFieldType.STRING).description("백준 문제 URL").optional(),
+						fieldWithPath("samples").type(JsonFieldType.ARRAY).description("입출력 예제 목록").optional(),
+						fieldWithPath("samples[].sampleIndex").type(JsonFieldType.NUMBER).description("예제 번호"),
+						fieldWithPath("samples[].input").type(JsonFieldType.STRING).description("예제 입력").optional(),
+						fieldWithPath("samples[].output").type(JsonFieldType.STRING).description("예제 출력").optional(),
+						fieldWithPath("tags").type(JsonFieldType.ARRAY).description("알고리즘 태그 목록").optional(),
+						fieldWithPath("tags[].name").type(JsonFieldType.STRING).description("태그 이름")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("문제 ID"),
+						fieldWithPath("data.problemNumber").type(JsonFieldType.NUMBER).description("백준 문제 번호"),
+						fieldWithPath("data.title").type(JsonFieldType.STRING).description("문제 제목"),
+						fieldWithPath("data.tier").type(JsonFieldType.STRING).description("난이도").optional(),
+						fieldWithPath("data.timeLimit").type(JsonFieldType.STRING).description("시간 제한").optional(),
+						fieldWithPath("data.memoryLimit").type(JsonFieldType.STRING).description("메모리 제한").optional(),
+						fieldWithPath("data.description").type(JsonFieldType.STRING).description("문제 설명").optional(),
+						fieldWithPath("data.inputDescription").type(JsonFieldType.STRING).description("입력 설명").optional(),
+						fieldWithPath("data.outputDescription").type(JsonFieldType.STRING).description("출력 설명").optional(),
+						fieldWithPath("data.url").type(JsonFieldType.STRING).description("백준 문제 URL").optional(),
+						fieldWithPath("data.samples").type(JsonFieldType.ARRAY).description("입출력 예제 목록"),
+						fieldWithPath("data.samples[].id").type(JsonFieldType.NUMBER).description("예제 ID"),
+						fieldWithPath("data.samples[].sampleIndex").type(JsonFieldType.NUMBER).description("예제 번호"),
+						fieldWithPath("data.samples[].input").type(JsonFieldType.STRING).description("예제 입력").optional(),
+						fieldWithPath("data.samples[].output").type(JsonFieldType.STRING).description("예제 출력").optional(),
+						fieldWithPath("data.algorithmTags").type(JsonFieldType.ARRAY).description("알고리즘 태그 목록"),
+						fieldWithPath("data.algorithmTags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+						fieldWithPath("data.algorithmTags[].name").type(JsonFieldType.STRING).description("태그 이름"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+}

--- a/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerTest.java
@@ -1,0 +1,149 @@
+package com.ujax.infrastructure.web.api.problem;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ujax.application.problem.ProblemService;
+import com.ujax.application.problem.dto.response.AlgorithmTagResponse;
+import com.ujax.application.problem.dto.response.ProblemResponse;
+import com.ujax.application.problem.dto.response.SampleResponse;
+import com.ujax.infrastructure.web.problem.ProblemController;
+import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+
+@WebMvcTest(ProblemController.class)
+class ProblemControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ProblemService problemService;
+
+	private ProblemResponse createMockResponse() {
+		return new ProblemResponse(
+			1L, 1000, "A+B", "Bronze V", "2 초", "128 MB",
+			"설명", "입력", "출력", "https://www.acmicpc.net/problem/1000",
+			List.of(new SampleResponse(1L, 1, "1 2", "3")),
+			List.of(new AlgorithmTagResponse(1L, "수학"))
+		);
+	}
+
+	@Nested
+	@DisplayName("문제 조회")
+	class GetProblem {
+
+		@Test
+		@DisplayName("ID로 문제를 조회한다")
+		void getProblem_Success() throws Exception {
+			// given
+			given(problemService.getProblem(1L)).willReturn(createMockResponse());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/problems/1"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.problemNumber").value(1000))
+				.andExpect(jsonPath("$.data.title").value("A+B"));
+		}
+	}
+
+	@Nested
+	@DisplayName("문제 번호로 조회")
+	class GetProblemByNumber {
+
+		@Test
+		@DisplayName("문제 번호로 문제를 조회한다")
+		void getProblemByNumber_Success() throws Exception {
+			// given
+			given(problemService.getProblemByNumber(1000)).willReturn(createMockResponse());
+
+			// when & then
+			mockMvc.perform(get("/api/v1/problems/number/1000"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.problemNumber").value(1000));
+		}
+	}
+
+	@Nested
+	@DisplayName("문제 생성")
+	class IngestProblem {
+
+		@Test
+		@DisplayName("문제를 생성한다")
+		void ingestProblem_Success() throws Exception {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "A+B", "Bronze V", "2 초", "128 MB",
+				"설명", "입력", "출력", null,
+				List.of(new ProblemIngestRequest.SampleDto(1, "1 2", "3")),
+				List.of(new ProblemIngestRequest.TagDto("수학"))
+			);
+			given(problemService.createProblem(any(ProblemIngestRequest.class)))
+				.willReturn(createMockResponse());
+
+			// when & then
+			mockMvc.perform(post("/api/v1/problems/ingest")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.problemNumber").value(1000));
+		}
+
+		@Test
+		@DisplayName("제목이 비어있으면 오류가 발생한다")
+		void ingestProblem_BlankTitle() throws Exception {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				1000, "", "Bronze V", null, null,
+				null, null, null, null, null, null
+			);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/problems/ingest")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("문제 번호가 0이하이면 오류가 발생한다")
+		void ingestProblem_InvalidProblemNumber() throws Exception {
+			// given
+			ProblemIngestRequest request = new ProblemIngestRequest(
+				0, "A+B", "Bronze V", null, null,
+				null, null, null, null, null, null
+			);
+
+			// when & then
+			mockMvc.perform(post("/api/v1/problems/ingest")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+	}
+}


### PR DESCRIPTION
# 관련 작업 / 이슈

> 관련된 이슈나 작업 번호를 링크해 주세요.

---

## 내용 요약 (Description)
> 백준 문제 데이터를 크롬 익스텐션으로 수집하여 백엔드에 저장하기 위한 Problem 도메인 구현

- Problem, Sample, AlgorithmTag 엔티티 및 Repository 구현
- ProblemService: 문제 등록/조회, solved.ac 태그 재사용 로직
- ProblemController: GET /problems/{id}, GET /problems/number/{num}, POST /problems/ingest
- ProblemIngestRequest DTO (@Positive, @NotBlank, @JsonProperty 매핑)
- ErrorCode에 PROBLEM_NOT_FOUND, DUPLICATE_PROBLEM 추가
- 전 계층 테스트 작성 (Entity, Repository, Service, Controller, RestDocs)

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명:
<img width="633" height="398" alt="image" src="https://github.com/user-attachments/assets/c118ff87-c43a-4a1c-aacb-cce8fb538317" />
<img width="639" height="328" alt="image" src="https://github.com/user-attachments/assets/3c814200-0832-4086-9d06-b3cd0507ed56" />

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [ ] Yes (호환성 깨짐 있음)
- [x] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.
<img width="927" height="243" alt="image" src="https://github.com/user-attachments/assets/ea673ade-2dab-4ebc-b6d1-727f8195d449" />


---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO: Submission 도메인 (별도 PR), 크롬 익스텐션 연동
- 추후 리팩터링/성능 개선 포인트: Submission과 Problem 연관관계 설계 논의 필요 (워크스페이스 분리/통합)
- 다른 모듈/서비스와의 의존성: `ujax-extention` repo의 크롬 익스텐션이 `POST
   /api/v1/problems/ingest`를 호출

