### PR TITLE
JWT + Spring Security + OAuth2 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.flywaydb:flyway-core'
@@ -119,8 +125,31 @@ tasks.register('copyOpenApiSpec', Copy) {
     from layout.buildDirectory.file("api-spec/openapi3.yaml")
     into "$projectDir/src/main/resources/static/swagger"
 }
+
+// 복사된 openapi3.yaml에 securitySchemes 자동 삽입
+tasks.register('patchOpenApiSecurity') {
+    dependsOn 'copyOpenApiSpec'
+    doLast {
+        def yamlFile = file("$projectDir/src/main/resources/static/swagger/openapi3.yaml")
+        def content = yamlFile.text
+        if (!content.contains('securitySchemes:')) {
+            content = content.replace(
+                    'tags: []',
+                    "security:\n- bearerAuth: []\ntags: []"
+            )
+            content = content.replace(
+                    'components:\n  schemas:',
+                    "components:\n  securitySchemes:\n    bearerAuth:\n      type: http\n      scheme: bearer\n      bearerFormat: JWT\n      description: \"로그인 후 받은 accessToken을 입력하세요\"\n  schemas:"
+            )
+            yamlFile.text = content
+            logger.lifecycle('Patched openapi3.yaml with JWT securitySchemes')
+        }
+    }
+}
+
 afterEvaluate {
     tasks.named('openapi3').configure { finalizedBy 'copyOpenApiSpec' }
+    tasks.named('copyOpenApiSpec').configure { finalizedBy 'patchOpenApiSecurity' }
 }
 
 bootJar {
@@ -172,6 +201,7 @@ def jacocoExcludes = [
         '**/dto/**',             // DTO
         '**/external/**',        // API Client
         '**/global/**',          // global 패키지 전체
+        '**/infrastructure/security/**', // Security
 ]
 
 // 리포트 생성

--- a/src/main/java/com/ujax/UjaxServerApplication.java
+++ b/src/main/java/com/ujax/UjaxServerApplication.java
@@ -2,8 +2,10 @@ package com.ujax;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class UjaxServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ujax/application/auth/AuthService.java
+++ b/src/main/java/com/ujax/application/auth/AuthService.java
@@ -1,0 +1,100 @@
+package com.ujax.application.auth;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.domain.user.AuthProvider;
+import com.ujax.domain.user.Password;
+import com.ujax.domain.user.User;
+import com.ujax.domain.user.UserRepository;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.ConflictException;
+import com.ujax.global.exception.common.NotFoundException;
+import com.ujax.global.exception.common.UnauthorizedException;
+import com.ujax.infrastructure.security.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenService refreshTokenService;
+
+	@Transactional
+	public AuthTokenResponse signup(String email, String password, String name) {
+		if (userRepository.existsByEmail(email)) {
+			throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+		}
+
+		User user = User.createLocalUser(email, Password.encode(password, passwordEncoder), name);
+		userRepository.save(user);
+
+		return issueTokens(user);
+	}
+
+	@Transactional
+	public AuthTokenResponse login(String email, String password) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS));
+
+		if (user.getProvider() != AuthProvider.LOCAL) {
+			throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+		}
+
+		if (!user.matchesPassword(password, passwordEncoder)) {
+			throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+		}
+
+		return issueTokens(user);
+	}
+
+	@Transactional
+	public AuthTokenResponse refresh(String refreshToken) {
+		User user = refreshTokenService.validate(refreshToken);
+		refreshTokenService.revoke(refreshToken);
+		return issueTokens(user);
+	}
+
+	@Transactional
+	public User findOrCreateOAuthUser(String email, String name, String profileImageUrl,
+		AuthProvider provider, String providerId) {
+		return userRepository.findByProviderAndProviderId(provider, providerId)
+			.orElseGet(() -> registerOAuthUser(email, name, profileImageUrl, provider, providerId));
+	}
+
+	@Transactional
+	public AuthTokenResponse oauthLogin(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+		return issueTokens(user);
+	}
+
+	@Transactional
+	public void logout(String refreshToken) {
+		refreshTokenService.revoke(refreshToken);
+	}
+
+	private User registerOAuthUser(String email, String name, String profileImageUrl,
+		AuthProvider provider, String providerId) {
+		if (userRepository.existsByEmail(email)) {
+			throw new ConflictException(ErrorCode.OAUTH_ACCOUNT_EXISTS);
+		}
+		User user = User.createOAuthUser(email, name, profileImageUrl, provider, providerId);
+		return userRepository.save(user);
+	}
+
+	private AuthTokenResponse issueTokens(User user) {
+		String accessToken = jwtTokenProvider.createAccessToken(
+			user.getId(), user.getRole(), user.getName(), user.getEmail()
+		);
+		String rawRefreshToken = refreshTokenService.issue(user);
+		return new AuthTokenResponse(accessToken, rawRefreshToken);
+	}
+}

--- a/src/main/java/com/ujax/application/auth/RefreshTokenService.java
+++ b/src/main/java/com/ujax/application/auth/RefreshTokenService.java
@@ -1,0 +1,80 @@
+package com.ujax.application.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ujax.domain.auth.RefreshToken;
+import com.ujax.domain.auth.RefreshTokenRepository;
+import com.ujax.domain.user.User;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.UnauthorizedException;
+import com.ujax.infrastructure.security.jwt.JwtProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final JwtProperties jwtProperties;
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	@Transactional
+	public String issue(User user) {
+		refreshTokenRepository.revokeAllByUserId(user.getId(), LocalDateTime.now());
+
+		String rawToken = generateRawToken();
+		String tokenHash = hashToken(rawToken);
+		LocalDateTime expiresAt = LocalDateTime.now()
+			.plusSeconds(jwtProperties.refreshExpiration() / 1000);
+
+		RefreshToken refreshToken = RefreshToken.create(user, tokenHash, expiresAt);
+		refreshTokenRepository.save(refreshToken);
+
+		return rawToken;
+	}
+
+	public User validate(String rawToken) {
+		String tokenHash = hashToken(rawToken);
+		RefreshToken refreshToken = refreshTokenRepository.findByTokenHashAndRevokedAtIsNull(tokenHash)
+			.orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_TOKEN));
+
+		if (refreshToken.isExpired()) {
+			throw new UnauthorizedException(ErrorCode.EXPIRED_TOKEN);
+		}
+
+		return refreshToken.getUser();
+	}
+
+	@Transactional
+	public void revoke(String rawToken) {
+		String tokenHash = hashToken(rawToken);
+		refreshTokenRepository.findByTokenHashAndRevokedAtIsNull(tokenHash)
+			.ifPresent(RefreshToken::revoke);
+	}
+
+	private String generateRawToken() {
+		byte[] bytes = new byte[48];
+		secureRandom.nextBytes(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
+	private String hashToken(String rawToken) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+			return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 algorithm not available", e);
+		}
+	}
+}

--- a/src/main/java/com/ujax/application/auth/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/ujax/application/auth/dto/response/AuthTokenResponse.java
@@ -1,0 +1,7 @@
+package com.ujax.application.auth.dto.response;
+
+public record AuthTokenResponse(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/ujax/domain/auth/RefreshToken.java
+++ b/src/main/java/com/ujax/domain/auth/RefreshToken.java
@@ -1,0 +1,68 @@
+package com.ujax.domain.auth;
+
+import java.time.LocalDateTime;
+
+import com.ujax.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(nullable = false, unique = true)
+	private String tokenHash;
+
+	@Column(nullable = false)
+	private LocalDateTime expiresAt;
+
+	/** null이면 유효, 값이 있으면 해지됨 */
+	private LocalDateTime revokedAt;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	private RefreshToken(User user, String tokenHash, LocalDateTime expiresAt) {
+		this.user = user;
+		this.tokenHash = tokenHash;
+		this.expiresAt = expiresAt;
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static RefreshToken create(User user, String tokenHash, LocalDateTime expiresAt) {
+		return new RefreshToken(user, tokenHash, expiresAt);
+	}
+
+	public boolean isExpired() {
+		return LocalDateTime.now().isAfter(expiresAt);
+	}
+
+	public boolean isRevoked() {
+		return revokedAt != null;
+	}
+
+	public void revoke() {
+		this.revokedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/ujax/domain/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/ujax/domain/auth/RefreshTokenRepository.java
@@ -1,0 +1,18 @@
+package com.ujax.domain.auth;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+	Optional<RefreshToken> findByTokenHashAndRevokedAtIsNull(String tokenHash);
+
+	@Modifying
+	@Query("UPDATE RefreshToken rt SET rt.revokedAt = :now WHERE rt.user.id = :userId AND rt.revokedAt IS NULL")
+	void revokeAllByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/ujax/domain/user/Password.java
+++ b/src/main/java/com/ujax/domain/user/Password.java
@@ -1,0 +1,52 @@
+package com.ujax.domain.user;
+
+import java.util.regex.Pattern;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.BadRequestException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+	private static final int MIN_LENGTH = 8;
+	private static final Pattern HAS_LETTER = Pattern.compile("[a-zA-Z]");
+	private static final Pattern HAS_DIGIT = Pattern.compile("[0-9]");
+
+	@Column(name = "password")
+	private String encodedValue;
+
+	private Password(String encodedValue) {
+		this.encodedValue = encodedValue;
+	}
+
+	public static Password ofEncoded(String encodedValue) {
+		return new Password(encodedValue);
+	}
+
+	public static Password encode(String rawPassword, PasswordEncoder encoder) {
+		validate(rawPassword);
+		return new Password(encoder.encode(rawPassword));
+	}
+
+	public boolean matches(String rawPassword, PasswordEncoder encoder) {
+		return encoder.matches(rawPassword, encodedValue);
+	}
+
+	private static void validate(String rawPassword) {
+		if (rawPassword.length() < MIN_LENGTH
+			|| !HAS_LETTER.matcher(rawPassword).find()
+			|| !HAS_DIGIT.matcher(rawPassword).find()) {
+			throw new BadRequestException(ErrorCode.INVALID_PASSWORD);
+		}
+	}
+}

--- a/src/main/java/com/ujax/domain/user/User.java
+++ b/src/main/java/com/ujax/domain/user/User.java
@@ -2,10 +2,12 @@ package com.ujax.domain.user;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.SQLDelete;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.ujax.domain.common.BaseEntity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,7 +42,8 @@ public class User extends BaseEntity {
 	private String email;
 
 	/** 비밀번호 (OAuth 사용 시 null) */
-	private String password;
+	@Embedded
+	private Password password;
 
 	@Column(nullable = false, length = 30)
 	private String name;
@@ -54,15 +57,20 @@ public class User extends BaseEntity {
 	/** OAuth 식별자 (자체 회원가입시 null) */
 	private String providerId;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 10)
+	private UserRole role;
+
 	@Builder
-	private User(String email, String password, String name, String profileImageUrl,
-		AuthProvider provider, String providerId) {
+	private User(String email, Password password, String name, String profileImageUrl,
+		AuthProvider provider, String providerId, UserRole role) {
 		this.email = email;
 		this.password = password;
 		this.name = name;
 		this.profileImageUrl = profileImageUrl != null ? profileImageUrl : DEFAULT_PROFILE_IMAGE_URL;
 		this.provider = provider;
 		this.providerId = providerId;
+		this.role = role != null ? role : UserRole.USER;
 	}
 
 	public static User createOAuthUser(String email, String name, String profileImageUrl,
@@ -73,16 +81,22 @@ public class User extends BaseEntity {
 			.profileImageUrl(profileImageUrl)
 			.provider(provider)
 			.providerId(providerId)
+			.role(UserRole.USER)
 			.build();
 	}
 
-	public static User createLocalUser(String email, String password, String name) {
+	public static User createLocalUser(String email, Password password, String name) {
 		return User.builder()
 			.email(email)
 			.password(password)
 			.name(name)
 			.provider(AuthProvider.LOCAL)
+			.role(UserRole.USER)
 			.build();
+	}
+
+	public boolean matchesPassword(String rawPassword, PasswordEncoder encoder) {
+		return password != null && password.matches(rawPassword, encoder);
 	}
 
 	public void updateProfile(String name, String profileImageUrl) {

--- a/src/main/java/com/ujax/domain/user/UserRole.java
+++ b/src/main/java/com/ujax/domain/user/UserRole.java
@@ -1,0 +1,16 @@
+package com.ujax.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+	USER("일반 사용자"),
+	ADMIN("관리자")
+
+	;
+
+	private final String text;
+}

--- a/src/main/java/com/ujax/global/exception/ErrorCode.java
+++ b/src/main/java/com/ujax/global/exception/ErrorCode.java
@@ -14,11 +14,13 @@ public enum ErrorCode {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "잘못된 파라미터 형식입니다."),
 	MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "C003", "필수 입력값이 누락되었습니다."),
 	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "잘못된 타입의 값입니다."),
+	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "C005", "비밀번호는 8자 이상이며, 영문과 숫자를 포함해야 합니다."),
 
 	// ==================== 401 Unauthorized ====================
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
+	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A004", "이메일 또는 비밀번호가 올바르지 않습니다."),
 
 	// ==================== 403 Forbidden ====================
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "A010", "접근 권한이 없습니다."),
@@ -41,6 +43,7 @@ public enum ErrorCode {
 	ALREADY_WORKSPACE_MEMBER(HttpStatus.CONFLICT, "D004", "이미 워크스페이스에 가입된 멤버입니다."),
 	DUPLICATE_PROBLEM(HttpStatus.CONFLICT, "D005", "이미 등록된 문제 번호입니다."),
 	WORKSPACE_NAME_DUPLICATE(HttpStatus.CONFLICT, "D006", "이미 존재하는 워크스페이스 이름입니다."),
+	OAUTH_ACCOUNT_EXISTS(HttpStatus.CONFLICT, "D008", "이미 다른 소셜 계정으로 가입된 이메일입니다."),
 
 	// ==================== 422 Unprocessable Entity ====================
 	UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "U001", "요청을 처리할 수 없습니다."),

--- a/src/main/java/com/ujax/infrastructure/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/ujax/infrastructure/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.ujax.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ujax/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,110 @@
+package com.ujax.infrastructure.security;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.infrastructure.security.jwt.JwtAuthenticationFilter;
+import com.ujax.infrastructure.security.oauth2.CustomOAuth2UserService;
+import com.ujax.infrastructure.security.oauth2.OAuth2LoginFailureHandler;
+import com.ujax.infrastructure.security.oauth2.OAuth2LoginSuccessHandler;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+	private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+	private final ObjectMapper objectMapper;
+
+	@Value("${app.ujax.base-url}")
+	private String baseUrl;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/api/v1/auth/**",
+					"/oauth2/**",
+					"/login/oauth2/**",
+					"/api/v1/problems/**",
+					"/api/v1/workspaces/explore",
+					"/api/v1/workspaces/search",
+					"/error"
+				).permitAll()
+				.requestMatchers("GET", "/api/v1/workspaces/{id}").permitAll()
+				.anyRequest().authenticated()
+			)
+			.oauth2Login(oauth2 -> oauth2
+				.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+				.successHandler(oAuth2LoginSuccessHandler)
+				.failureHandler(oAuth2LoginFailureHandler)
+			)
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint((request, response, authException) ->
+					writeErrorResponse(response, HttpStatus.UNAUTHORIZED, ErrorCode.UNAUTHORIZED))
+				.accessDeniedHandler((request, response, accessDeniedException) ->
+					writeErrorResponse(response, HttpStatus.FORBIDDEN, ErrorCode.ACCESS_DENIED))
+			)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	private CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of(baseUrl));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/api/**", configuration);
+		return source;
+	}
+
+	private void writeErrorResponse(HttpServletResponse response, HttpStatus status,
+		ErrorCode errorCode) throws IOException {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+		problemDetail.setType(URI.create("/docs/index.html#error-code-list"));
+		problemDetail.setTitle(errorCode.getCode());
+		problemDetail.setDetail(errorCode.getDetail());
+		problemDetail.setProperty("exception", "SecurityException");
+		problemDetail.setProperty("timestamp", LocalDateTime.now());
+
+		response.setStatus(status.value());
+		response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/SwaggerSecurityConfig.java
+++ b/src/main/java/com/ujax/infrastructure/security/SwaggerSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.ujax.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SwaggerSecurityConfig {
+
+	@Bean
+	@Order(0)
+	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher(
+				"/swagger/**",
+				"/swagger-ui/**",
+				"/swagger-ui.html",
+				"/v3/api-docs/**",
+				"/static/**",
+				"/docs/**"
+			)
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+		return http.build();
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/UserPrincipal.java
+++ b/src/main/java/com/ujax/infrastructure/security/UserPrincipal.java
@@ -1,0 +1,68 @@
+package com.ujax.infrastructure.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.ujax.domain.user.User;
+import com.ujax.domain.user.UserRole;
+
+import io.jsonwebtoken.Claims;
+import lombok.Getter;
+
+@Getter
+public class UserPrincipal implements OAuth2User {
+
+	private final Long userId;
+	private final UserRole role;
+	private final String name;
+	private final String email;
+	private final Map<String, Object> attributes;
+
+	private UserPrincipal(Long userId, UserRole role, String name, String email, Map<String, Object> attributes) {
+		this.userId = userId;
+		this.role = role;
+		this.name = name;
+		this.email = email;
+		this.attributes = attributes;
+	}
+
+	public static UserPrincipal fromClaims(Claims claims) {
+		return new UserPrincipal(
+			Long.valueOf(claims.getSubject()),
+			UserRole.valueOf(claims.get("role", String.class)),
+			claims.get("name", String.class),
+			claims.get("email", String.class),
+			Collections.emptyMap()
+		);
+	}
+
+	public static UserPrincipal fromUser(User user, Map<String, Object> attributes) {
+		return new UserPrincipal(
+			user.getId(),
+			user.getRole(),
+			user.getName(),
+			user.getEmail(),
+			attributes
+		);
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ujax/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.ujax.infrastructure.security.jwt;
+
+import java.io.IOException;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ujax.infrastructure.security.UserPrincipal;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain) throws ServletException, IOException {
+
+		String token = resolveToken(request);
+
+		if (token != null) {
+			try {
+				Claims claims = jwtTokenProvider.parseToken(token);
+				UserPrincipal principal = UserPrincipal.fromClaims(claims);
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} catch (Exception e) {
+				log.debug("JWT authentication failed: {}", e.getMessage());
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/jwt/JwtProperties.java
+++ b/src/main/java/com/ujax/infrastructure/security/jwt/JwtProperties.java
@@ -1,0 +1,7 @@
+package com.ujax.infrastructure.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(String secret, long accessExpiration, long refreshExpiration) {
+}

--- a/src/main/java/com/ujax/infrastructure/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ujax/infrastructure/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,60 @@
+package com.ujax.infrastructure.security.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.ujax.domain.user.UserRole;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.UnauthorizedException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	private final SecretKey secretKey;
+	private final long accessExpiration;
+
+	public JwtTokenProvider(JwtProperties jwtProperties) {
+		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+		this.accessExpiration = jwtProperties.accessExpiration();
+	}
+
+	public String createAccessToken(Long userId, UserRole role, String name, String email) {
+		Date now = new Date();
+		Date expiry = new Date(now.getTime() + accessExpiration);
+
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.claim("role", role.name())
+			.claim("name", name)
+			.claim("email", email)
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public Claims parseToken(String token) {
+		try {
+			return Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+		} catch (ExpiredJwtException e) {
+			throw new UnauthorizedException(ErrorCode.EXPIRED_TOKEN);
+		} catch (Exception e) {
+			throw new UnauthorizedException(ErrorCode.INVALID_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.ujax.infrastructure.security.oauth2;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.ujax.application.auth.AuthService;
+import com.ujax.domain.user.AuthProvider;
+import com.ujax.domain.user.User;
+import com.ujax.infrastructure.security.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+	private final AuthService authService;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		AuthProvider provider = AuthProvider.valueOf(registrationId.toUpperCase());
+		OAuth2UserInfo userInfo = extractUserInfo(registrationId, oAuth2User);
+
+		try {
+			User user = authService.findOrCreateOAuthUser(
+				userInfo.getEmail(), userInfo.getName(), userInfo.getProfileImageUrl(),
+				provider, userInfo.getProviderId()
+			);
+			return UserPrincipal.fromUser(user, oAuth2User.getAttributes());
+		} catch (Exception e) {
+			throw new OAuth2AuthenticationException(
+				new OAuth2Error("oauth_error", e.getMessage(), null), e
+			);
+		}
+	}
+
+	private OAuth2UserInfo extractUserInfo(String registrationId, OAuth2User oAuth2User) {
+		return switch (registrationId.toLowerCase()) {
+			case "google" -> new GoogleUserInfo(oAuth2User.getAttributes());
+			case "kakao" -> new KakaoUserInfo(oAuth2User.getAttributes());
+			default -> throw new OAuth2AuthenticationException("지원하지 않는 OAuth2 프로바이더입니다: " + registrationId);
+		};
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/GoogleUserInfo.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/GoogleUserInfo.java
@@ -1,0 +1,32 @@
+package com.ujax.infrastructure.security.oauth2;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+	private final Map<String, Object> attributes;
+
+	public GoogleUserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getProviderId() {
+		return (String) attributes.get("sub");
+	}
+
+	@Override
+	public String getEmail() {
+		return (String) attributes.get("email");
+	}
+
+	@Override
+	public String getName() {
+		return (String) attributes.get("name");
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return (String) attributes.get("picture");
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/KakaoUserInfo.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/KakaoUserInfo.java
@@ -1,0 +1,59 @@
+package com.ujax.infrastructure.security.oauth2;
+
+import java.util.Map;
+
+/**
+ * @SuppressWarnings("unchecked") — 컴파일러의 "unchecked cast" 경고를 억제한다.
+ * @see <a href="https://docs.oracle.com/javase/tutorial/java/generics/erasure.html">Type Erasure (Oracle Docs)</a>
+ */
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+	private final Map<String, Object> attributes;
+
+	public KakaoUserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getProviderId() {
+		return String.valueOf(attributes.get("id"));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public String getEmail() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+		if (kakaoAccount == null) {
+			return null;
+		}
+		return (String)kakaoAccount.get("email");
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public String getName() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+		if (kakaoAccount == null) {
+			return null;
+		}
+		Map<String, Object> profile = (Map<String, Object>)kakaoAccount.get("profile");
+		if (profile == null) {
+			return null;
+		}
+		return (String)profile.get("nickname");
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public String getProfileImageUrl() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+		if (kakaoAccount == null) {
+			return null;
+		}
+		Map<String, Object> profile = (Map<String, Object>)kakaoAccount.get("profile");
+		if (profile == null) {
+			return null;
+		}
+		return (String)profile.get("profile_image_url");
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2LoginFailureHandler.java
@@ -1,0 +1,40 @@
+package com.ujax.infrastructure.security.oauth2;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+	@Value("${app.ujax.frontend-callback-url}")
+	private String frontendCallbackUrl;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		String errorCode = "oauth_failed";
+		String errorMessage = exception.getMessage();
+
+		if (exception instanceof OAuth2AuthenticationException oauthEx) {
+			errorCode = oauthEx.getError().getErrorCode();
+		}
+
+		String redirectUrl = UriComponentsBuilder.fromUriString(frontendCallbackUrl)
+			.queryParam("error", errorCode)
+			.queryParam("message", URLEncoder.encode(errorMessage, StandardCharsets.UTF_8))
+			.build()
+			.toUriString();
+		response.sendRedirect(redirectUrl);
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,43 @@
+package com.ujax.infrastructure.security.oauth2;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.ujax.application.auth.AuthService;
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.infrastructure.security.UserPrincipal;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final AuthService authService;
+
+	@Value("${app.ujax.frontend-callback-url}")
+	private String frontendCallbackUrl;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+
+		UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+		AuthTokenResponse tokens = authService.oauthLogin(principal.getUserId());
+
+		String redirectUrl = UriComponentsBuilder.fromUriString(frontendCallbackUrl)
+			.queryParam("accessToken", tokens.accessToken())
+			.queryParam("refreshToken", tokens.refreshToken())
+			.build()
+			.toUriString();
+
+		response.sendRedirect(redirectUrl);
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/ujax/infrastructure/security/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,12 @@
+package com.ujax.infrastructure.security.oauth2;
+
+public interface OAuth2UserInfo {
+
+	String getProviderId();
+
+	String getEmail();
+
+	String getName();
+
+	String getProfileImageUrl();
+}

--- a/src/main/java/com/ujax/infrastructure/web/auth/AuthController.java
+++ b/src/main/java/com/ujax/infrastructure/web/auth/AuthController.java
@@ -1,0 +1,45 @@
+package com.ujax.infrastructure.web.auth;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ujax.application.auth.AuthService;
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.global.dto.ApiResponse;
+import com.ujax.infrastructure.web.auth.dto.request.LoginRequest;
+import com.ujax.infrastructure.web.auth.dto.request.RefreshRequest;
+import com.ujax.infrastructure.web.auth.dto.request.SignupRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/signup")
+	public ApiResponse<AuthTokenResponse> signup(@Valid @RequestBody SignupRequest request) {
+		return ApiResponse.success(authService.signup(request.email(), request.password(), request.name()));
+	}
+
+	@PostMapping("/login")
+	public ApiResponse<AuthTokenResponse> login(@Valid @RequestBody LoginRequest request) {
+		return ApiResponse.success(authService.login(request.email(), request.password()));
+	}
+
+	@PostMapping("/refresh")
+	public ApiResponse<AuthTokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+		return ApiResponse.success(authService.refresh(request.refreshToken()));
+	}
+
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(@Valid @RequestBody RefreshRequest request) {
+		authService.logout(request.refreshToken());
+		return ApiResponse.success();
+	}
+}

--- a/src/main/java/com/ujax/infrastructure/web/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/ujax/infrastructure/web/auth/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ujax.infrastructure.web.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+	@NotBlank String email,
+	@NotBlank String password
+) {
+}

--- a/src/main/java/com/ujax/infrastructure/web/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/com/ujax/infrastructure/web/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.ujax.infrastructure.web.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+	@NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/ujax/infrastructure/web/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/ujax/infrastructure/web/auth/dto/request/SignupRequest.java
@@ -1,0 +1,11 @@
+package com.ujax.infrastructure.web.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+	@NotBlank @Email String email,
+	@NotBlank String password,
+	@NotBlank String name
+) {
+}

--- a/src/main/java/com/ujax/infrastructure/web/user/UserController.java
+++ b/src/main/java/com/ujax/infrastructure/web/user/UserController.java
@@ -1,6 +1,6 @@
 package com.ujax.infrastructure.web.user;
 
-import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ujax.application.user.UserService;
 import com.ujax.application.user.dto.response.UserResponse;
 import com.ujax.global.dto.ApiResponse;
+import com.ujax.infrastructure.security.UserPrincipal;
 import com.ujax.infrastructure.web.user.dto.request.UserUpdateRequest;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -22,24 +24,22 @@ public class UserController {
 
 	private final UserService userService;
 
-	// TODO: Security 적용 후 @AuthenticationPrincipal로 userId 받기
 	@GetMapping("/me")
-	public ApiResponse<UserResponse> getMe() {
-		// TODO: Security 적용 전까지 임시로 userId 1 사용
-		Long userId = 1L;
-		return ApiResponse.success(userService.getUser(userId));
+	public ApiResponse<UserResponse> getMe(@AuthenticationPrincipal UserPrincipal principal) {
+		return ApiResponse.success(userService.getUser(principal.getUserId()));
 	}
 
 	@PatchMapping("/me")
-	public ApiResponse<UserResponse> updateMe(@Valid @RequestBody UserUpdateRequest request) {
-		Long userId = 1L;
-		return ApiResponse.success(userService.updateUser(userId, request.name(), request.profileImageUrl()));
+	public ApiResponse<UserResponse> updateMe(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@Valid @RequestBody UserUpdateRequest request
+	) {
+		return ApiResponse.success(userService.updateUser(principal.getUserId(), request.name(), request.profileImageUrl()));
 	}
 
 	@DeleteMapping("/me")
-	public ApiResponse<Void> deleteMe() {
-		Long userId = 1L;
-		userService.deleteUser(userId);
+	public ApiResponse<Void> deleteMe(@AuthenticationPrincipal UserPrincipal principal) {
+		userService.deleteUser(principal.getUserId());
 		return ApiResponse.success();
 	}
 }

--- a/src/main/java/com/ujax/infrastructure/web/workspace/WorkspaceController.java
+++ b/src/main/java/com/ujax/infrastructure/web/workspace/WorkspaceController.java
@@ -1,5 +1,6 @@
 package com.ujax.infrastructure.web.workspace;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import com.ujax.application.workspace.dto.response.WorkspaceResponse;
 import com.ujax.application.workspace.dto.response.WorkspaceSettingsResponse;
 import com.ujax.global.dto.PageResponse;
 import com.ujax.global.dto.ApiResponse;
+import com.ujax.infrastructure.security.UserPrincipal;
 import com.ujax.infrastructure.web.workspace.dto.request.CreateWorkspaceRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.InviteWorkspaceMemberRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.UpdateWorkspaceRequest;
@@ -52,8 +54,8 @@ public class WorkspaceController {
 	}
 
 	@GetMapping
-	public ApiResponse<WorkspaceListResponse> listMyWorkspaces(@RequestParam Long userId) {
-		return ApiResponse.success(workspaceService.listMyWorkspaces(userId));
+	public ApiResponse<WorkspaceListResponse> listMyWorkspaces(@AuthenticationPrincipal UserPrincipal principal) {
+		return ApiResponse.success(workspaceService.listMyWorkspaces(principal.getUserId()));
 	}
 
 	@GetMapping("/{workspaceId}")
@@ -64,65 +66,68 @@ public class WorkspaceController {
 	@GetMapping("/{workspaceId}/settings")
 	public ApiResponse<WorkspaceSettingsResponse> getWorkspaceSettings(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		return ApiResponse.success(workspaceService.getWorkspaceSettings(workspaceId, userId));
+		return ApiResponse.success(workspaceService.getWorkspaceSettings(workspaceId, principal.getUserId()));
 	}
 
 	@GetMapping("/{workspaceId}/members")
 	public ApiResponse<WorkspaceMemberListResponse> listWorkspaceMembers(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		return ApiResponse.success(workspaceService.listWorkspaceMembers(workspaceId, userId));
+		return ApiResponse.success(workspaceService.listWorkspaceMembers(workspaceId, principal.getUserId()));
 	}
 
 	@GetMapping("/{workspaceId}/members/me")
 	public ApiResponse<WorkspaceMemberResponse> getMyWorkspaceMember(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		return ApiResponse.success(workspaceService.getMyWorkspaceMember(workspaceId, userId));
+		return ApiResponse.success(workspaceService.getMyWorkspaceMember(workspaceId, principal.getUserId()));
 	}
 
 	@PatchMapping("/{workspaceId}/members/me/nickname")
 	public ApiResponse<WorkspaceMemberResponse> updateMyWorkspaceNickname(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@Valid @RequestBody UpdateWorkspaceMemberNicknameRequest request
 	) {
 		return ApiResponse.success(
-			workspaceService.updateMyWorkspaceNickname(workspaceId, userId, request.nickname())
+			workspaceService.updateMyWorkspaceNickname(workspaceId, principal.getUserId(), request.nickname())
 		);
 	}
 
 	@PostMapping("/{workspaceId}/members/invite")
 	public ApiResponse<Void> inviteWorkspaceMember(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@Valid @RequestBody InviteWorkspaceMemberRequest request
 	) {
-		workspaceService.inviteWorkspaceMember(workspaceId, userId, request.email());
+		workspaceService.inviteWorkspaceMember(workspaceId, principal.getUserId(), request.email());
 		return ApiResponse.success();
 	}
 
 	@PostMapping
-	public ApiResponse<WorkspaceResponse> createWorkspace(@Valid @RequestBody CreateWorkspaceRequest request) {
+	public ApiResponse<WorkspaceResponse> createWorkspace(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@Valid @RequestBody CreateWorkspaceRequest request
+	) {
 		return ApiResponse.success(
-			workspaceService.createWorkspace(request.name(), request.description(), request.userId())
+			workspaceService.createWorkspace(request.name(), request.description(), principal.getUserId())
 		);
 	}
 
 	@PatchMapping("/{workspaceId}")
 	public ApiResponse<WorkspaceResponse> updateWorkspace(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@Valid @RequestBody UpdateWorkspaceRequest request
 	) {
 		return ApiResponse.success(
 			workspaceService.updateWorkspace(
 				workspaceId,
-				userId,
+				principal.getUserId(),
 				request.name(),
 				request.description(),
 				request.mmWebhookUrl()
@@ -133,9 +138,9 @@ public class WorkspaceController {
 	@DeleteMapping("/{workspaceId}")
 	public ApiResponse<Void> deleteWorkspace(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		workspaceService.deleteWorkspace(workspaceId, userId);
+		workspaceService.deleteWorkspace(workspaceId, principal.getUserId());
 		return ApiResponse.success();
 	}
 
@@ -143,10 +148,10 @@ public class WorkspaceController {
 	public ApiResponse<Void> updateWorkspaceMemberRole(
 		@PathVariable Long workspaceId,
 		@PathVariable Long workspaceMemberId,
-		@RequestParam Long userId,
+		@AuthenticationPrincipal UserPrincipal principal,
 		@Valid @RequestBody UpdateWorkspaceMemberRoleRequest request
 	) {
-		workspaceService.updateWorkspaceMemberRole(workspaceId, userId, workspaceMemberId, request.role());
+		workspaceService.updateWorkspaceMemberRole(workspaceId, principal.getUserId(), workspaceMemberId, request.role());
 		return ApiResponse.success();
 	}
 
@@ -154,18 +159,18 @@ public class WorkspaceController {
 	public ApiResponse<Void> removeWorkspaceMember(
 		@PathVariable Long workspaceId,
 		@PathVariable Long workspaceMemberId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		workspaceService.removeWorkspaceMember(workspaceId, userId, workspaceMemberId);
+		workspaceService.removeWorkspaceMember(workspaceId, principal.getUserId(), workspaceMemberId);
 		return ApiResponse.success();
 	}
 
 	@DeleteMapping("/{workspaceId}/members/me")
 	public ApiResponse<Void> leaveWorkspace(
 		@PathVariable Long workspaceId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		workspaceService.leaveWorkspace(workspaceId, userId);
+		workspaceService.leaveWorkspace(workspaceId, principal.getUserId());
 		return ApiResponse.success();
 	}
 }

--- a/src/main/java/com/ujax/infrastructure/web/workspace/dto/request/CreateWorkspaceRequest.java
+++ b/src/main/java/com/ujax/infrastructure/web/workspace/dto/request/CreateWorkspaceRequest.java
@@ -1,11 +1,9 @@
 package com.ujax.infrastructure.web.workspace.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record CreateWorkspaceRequest(
 	@NotBlank String name,
-	String description,
-	@NotNull Long userId
+	String description
 ) {
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,16 @@ spring:
   flyway:
     enabled: false
 
+app:
+  ujax:
+    base-url: http://localhost:5173
+    frontend-callback-url: http://localhost:5173/auth/callback
+
+
+spring.security.oauth2.client:
+  registration:
+    google:
+      redirect-uri: http://localhost:8080/login/oauth2/code/google
+    kakao:
+      redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,34 @@ spring:
         "[mail.smtp.writetimeout]": 5000
 
 app:
+  jwt:
+    secret: ${JWT_SECRET:defaultDevSecretKeyThatIsAtLeast256BitsLongForHmacSha256Algorithm}
+    access-expiration: 1800000
+    refresh-expiration: 2592000000
   ujax:
     base-url: ${UJAX_BASE_URL:https://ujax.site}
+    frontend-callback-url: ${UJAX_FRONTEND_CALLBACK:https://ujax.site/auth/callback}
     mail:
       from: ${UJAX_MAIL_FROM:noreply@ujax.site}
+
+spring.security.oauth2.client:
+  registration:
+    google:
+      client-id: ${GOOGLE_CLIENT_ID:google-client-id}
+      client-secret: ${GOOGLE_CLIENT_SECRET:google-client-secret}
+      redirect-uri: ${GOOGLE_REDIRECT_URI}
+      scope: email, profile
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:kakao-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:kakao-client-secret}
+      redirect-uri: ${KAKAO_REDIRECT_URI}
+      client-authentication-method: client_secret_post
+      authorization-grant-type: authorization_code
+      scope: profile_nickname, account_email, profile_image
+
+  provider:
+    kakao:
+      authorization-uri: https://kauth.kakao.com/oauth/authorize
+      token-uri: https://kauth.kakao.com/oauth/token
+      user-info-uri: https://kapi.kakao.com/v2/user/me
+      user-name-attribute: id

--- a/src/main/resources/static/swagger/openapi3.yaml
+++ b/src/main/resources/static/swagger/openapi3.yaml
@@ -1,0 +1,2172 @@
+openapi: 3.0.1
+info:
+  title: ujax API
+  description: 백준 알고리즘 스터디 프로젝트 백엔드 API
+  version: 0.0.1-SNAPSHOT
+servers:
+- url: http://localhost:8080
+security:
+- bearerAuth: []
+tags: []
+paths:
+  /api/v1/workspaces:
+    get:
+      tags:
+      - Workspace
+      summary: 내 워크스페이스 목록 조회
+      description: 유저가 속한 워크스페이스 목록을 조회합니다
+      operationId: workspace-my-list
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceList"
+              examples:
+                workspace-my-list:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "items" : [ {
+                          "id" : 1,
+                          "name" : "워크스페이스",
+                          "description" : "소개"
+                        } ]
+                      },
+                      "message" : null
+                    }
+    post:
+      tags:
+      - Workspace
+      summary: 워크스페이스 생성
+      description: 워크스페이스 생성
+      operationId: workspace-create
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/CreateWorkspaceRequest"
+            examples:
+              workspace-create-error:
+                value: |-
+                  {
+                    "name" : "",
+                    "description" : "소개"
+                  }
+              workspace-create:
+                value: |-
+                  {
+                    "name" : "워크스페이스",
+                    "description" : "소개"
+                  }
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Validation"
+              examples:
+                workspace-create-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C001",
+                      "status" : 400,
+                      "detail" : "잘못된 요청 형식입니다.",
+                      "instance" : "/api/v1/workspaces",
+                      "exception" : "MethodArgumentNotValidException",
+                      "timestamp" : "2026-02-12T15:43:52.42326",
+                      "fieldErrors" : [ {
+                        "field" : "name",
+                        "rejectedValue" : "",
+                        "message" : "must not be blank"
+                      } ]
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceResponse"
+              examples:
+                workspace-create:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "name" : "워크스페이스",
+                        "description" : "소개"
+                      },
+                      "message" : null
+                    }
+  /api/v1/auth/login:
+    post:
+      tags:
+      - Auth
+      summary: 로그인
+      description: 이메일/비밀번호로 로그인합니다
+      operationId: auth-login
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+            examples:
+              auth-login:
+                value: |-
+                  {
+                    "email" : "test@example.com",
+                    "password" : "password123"
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-AuthTokenResponse"
+              examples:
+                auth-login:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "accessToken" : "access.token.here",
+                        "refreshToken" : "refresh.token.here"
+                      },
+                      "message" : null
+                    }
+  /api/v1/auth/logout:
+    post:
+      tags:
+      - Auth
+      summary: 로그아웃
+      description: 리프레시 토큰을 해지합니다
+      operationId: auth-logout
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/RefreshRequest"
+            examples:
+              auth-logout:
+                value: |-
+                  {
+                    "refreshToken" : "refresh.token.here"
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                auth-logout:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+  /api/v1/auth/refresh:
+    post:
+      tags:
+      - Auth
+      summary: 토큰 갱신
+      description: 리프레시 토큰으로 새 토큰을 발급받습니다
+      operationId: auth-refresh
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/RefreshRequest"
+            examples:
+              auth-refresh:
+                value: |-
+                  {
+                    "refreshToken" : "refresh.token.here"
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-AuthTokenResponse"
+              examples:
+                auth-refresh:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "accessToken" : "new.access.token",
+                        "refreshToken" : "new.refresh.token"
+                      },
+                      "message" : null
+                    }
+  /api/v1/auth/signup:
+    post:
+      tags:
+      - Auth
+      summary: 회원가입
+      description: 이메일/비밀번호로 회원가입합니다
+      operationId: auth-signup
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+            examples:
+              auth-signup:
+                value: |-
+                  {
+                    "email" : "test@example.com",
+                    "password" : "password123",
+                    "name" : "테스트유저"
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-AuthTokenResponse"
+              examples:
+                auth-signup:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "accessToken" : "access.token.here",
+                        "refreshToken" : "refresh.token.here"
+                      },
+                      "message" : null
+                    }
+  /api/v1/problems/ingest:
+    post:
+      tags:
+      - Problem
+      summary: 문제 등록
+      description: 크롤러에서 수집한 백준 문제를 등록합니다
+      operationId: problem-ingest
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/ProblemIngestRequest"
+            examples:
+              problem-ingest:
+                value: |-
+                  {
+                    "problemNum" : 1000,
+                    "title" : "A+B",
+                    "tier" : "Bronze V",
+                    "timeLimit" : "2 초",
+                    "memoryLimit" : "128 MB",
+                    "problemDesc" : "두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+                    "problemInput" : "첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+                    "problemOutput" : "첫째 줄에 A+B를 출력한다.",
+                    "url" : "https://www.acmicpc.net/problem/1000",
+                    "samples" : [ {
+                      "sampleIndex" : 1,
+                      "input" : "1 2",
+                      "output" : "3"
+                    }, {
+                      "sampleIndex" : 2,
+                      "input" : "3 4",
+                      "output" : "7"
+                    } ],
+                    "tags" : [ {
+                      "name" : "수학"
+                    }, {
+                      "name" : "구현"
+                    } ]
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-ProblemResponse"
+              examples:
+                problem-ingest:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "problemNumber" : 1000,
+                        "title" : "A+B",
+                        "tier" : "Bronze V",
+                        "timeLimit" : "2 초",
+                        "memoryLimit" : "128 MB",
+                        "description" : "두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+                        "inputDescription" : "첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+                        "outputDescription" : "첫째 줄에 A+B를 출력한다.",
+                        "url" : "https://www.acmicpc.net/problem/1000",
+                        "samples" : [ {
+                          "id" : 1,
+                          "sampleIndex" : 1,
+                          "input" : "1 2",
+                          "output" : "3"
+                        }, {
+                          "id" : 2,
+                          "sampleIndex" : 2,
+                          "input" : "3 4",
+                          "output" : "7"
+                        } ],
+                        "algorithmTags" : [ {
+                          "id" : 1,
+                          "name" : "수학"
+                        }, {
+                          "id" : 2,
+                          "name" : "구현"
+                        } ]
+                      },
+                      "message" : null
+                    }
+  /api/v1/problems/{problemId}:
+    get:
+      tags:
+      - Problem
+      summary: 문제 조회
+      description: 문제 ID로 문제를 조회합니다
+      operationId: problem-get
+      parameters:
+      - name: problemId
+        in: path
+        description: 문제 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-ProblemResponse"
+              examples:
+                problem-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "problemNumber" : 1000,
+                        "title" : "A+B",
+                        "tier" : "Bronze V",
+                        "timeLimit" : "2 초",
+                        "memoryLimit" : "128 MB",
+                        "description" : "두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+                        "inputDescription" : "첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+                        "outputDescription" : "첫째 줄에 A+B를 출력한다.",
+                        "url" : "https://www.acmicpc.net/problem/1000",
+                        "samples" : [ {
+                          "id" : 1,
+                          "sampleIndex" : 1,
+                          "input" : "1 2",
+                          "output" : "3"
+                        }, {
+                          "id" : 2,
+                          "sampleIndex" : 2,
+                          "input" : "3 4",
+                          "output" : "7"
+                        } ],
+                        "algorithmTags" : [ {
+                          "id" : 1,
+                          "name" : "수학"
+                        }, {
+                          "id" : 2,
+                          "name" : "구현"
+                        } ]
+                      },
+                      "message" : null
+                    }
+  /api/v1/users/me:
+    get:
+      tags:
+      - User
+      summary: 내 정보 조회
+      description: 로그인한 사용자의 정보를 조회합니다
+      operationId: user-get-me
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-UserResponse"
+              examples:
+                user-get-me:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "email" : "test@example.com",
+                        "name" : "테스트유저",
+                        "profileImageUrl" : "https://example.com/profile.jpg",
+                        "provider" : "GOOGLE"
+                      },
+                      "message" : null
+                    }
+    delete:
+      tags:
+      - User
+      summary: 회원 탈퇴
+      description: 로그인한 사용자의 계정을 삭제합니다
+      operationId: user-delete-me
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                user-delete-me:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+    patch:
+      tags:
+      - User
+      summary: 내 정보 수정
+      description: 로그인한 사용자의 정보를 수정합니다
+      operationId: user-update-me
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/UserUpdateRequest"
+            examples:
+              user-update-me:
+                value: |-
+                  {
+                    "name" : "수정된이름",
+                    "profileImageUrl" : "https://example.com/new-profile.jpg"
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-UserResponse"
+              examples:
+                user-update-me:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "email" : "test@example.com",
+                        "name" : "수정된이름",
+                        "profileImageUrl" : "https://example.com/new-profile.jpg",
+                        "provider" : "GOOGLE"
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/explore:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 탐색 목록 조회
+      description: 워크스페이스 탐색 페이지에서 목록을 조회합니다
+      operationId: workspace-explore
+      parameters:
+      - name: page
+        in: query
+        description: 페이지 번호
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: 페이지 크기
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceExplore"
+              examples:
+                workspace-explore:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "content" : [ {
+                          "id" : 1,
+                          "name" : "워크스페이스",
+                          "description" : "소개"
+                        } ],
+                        "page" : {
+                          "page" : 0,
+                          "size" : 20,
+                          "totalElements" : 1,
+                          "totalPages" : 1,
+                          "first" : true,
+                          "last" : true
+                        }
+                      },
+                      "message" : null
+                    }
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-InvalidParameter"
+              examples:
+                workspace-explore-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C004",
+                      "status" : 400,
+                      "detail" : "파라미터 'page'의 타입이 올바르지 않습니다. (기대 타입: int)",
+                      "instance" : "/api/v1/workspaces/explore",
+                      "exception" : "MethodArgumentTypeMismatchException",
+                      "timestamp" : "2026-02-12T15:43:52.351218"
+                    }
+  /api/v1/workspaces/search:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 검색
+      description: 워크스페이스 검색
+      operationId: workspace-search
+      parameters:
+      - name: name
+        in: query
+        description: 검색어
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: 페이지 번호
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: 페이지 크기
+        required: false
+        schema:
+          type: string
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-MissingParameter"
+              examples:
+                workspace-search-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C003",
+                      "status" : 400,
+                      "detail" : "필수 파라미터 'name'이(가) 누락되었습니다.",
+                      "instance" : "/api/v1/workspaces/search",
+                      "exception" : "MissingServletRequestParameterException",
+                      "timestamp" : "2026-02-12T15:43:52.575377"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceSearch"
+              examples:
+                workspace-search:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "content" : [ {
+                          "id" : 1,
+                          "name" : "워크스페이스",
+                          "description" : "소개"
+                        } ],
+                        "page" : {
+                          "page" : 0,
+                          "size" : 20,
+                          "totalElements" : 1,
+                          "totalPages" : 1,
+                          "first" : true,
+                          "last" : true
+                        }
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 상세 조회
+      description: 워크스페이스 상세 조회
+      operationId: workspace-get
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "404":
+          description: "404"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-NotFound"
+              examples:
+                workspace-get-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "R003",
+                      "status" : 404,
+                      "detail" : "워크스페이스를 찾을 수 없습니다.",
+                      "instance" : "/api/v1/workspaces/999",
+                      "exception" : "NotFoundException",
+                      "timestamp" : "2026-02-12T15:43:52.628645"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceResponse"
+              examples:
+                workspace-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "name" : "워크스페이스",
+                        "description" : "소개"
+                      },
+                      "message" : null
+                    }
+    delete:
+      tags:
+      - Workspace
+      summary: 워크스페이스 삭제
+      description: 워크스페이스를 삭제합니다
+      operationId: workspace-delete
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                workspace-delete:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-delete-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A014",
+                      "status" : 403,
+                      "detail" : "소유자만 이 작업을 수행할 수 있습니다.",
+                      "instance" : "/api/v1/workspaces/1",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.441233"
+                    }
+    patch:
+      tags:
+      - Workspace
+      summary: 워크스페이스 수정
+      description: 워크스페이스 정보를 수정합니다
+      operationId: workspace-update
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/UpdateWorkspaceRequest"
+            examples:
+              workspace-update:
+                value: |-
+                  {
+                    "name" : "새 이름",
+                    "description" : "새 소개",
+                    "mmWebhookUrl" : "https://hook.example.com"
+                  }
+              workspace-update-error:
+                value: |-
+                  {
+                    "name" : "",
+                    "description" : "새 소개",
+                    "mmWebhookUrl" : null
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceResponse"
+              examples:
+                workspace-update:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "name" : "새 이름",
+                        "description" : "새 소개"
+                      },
+                      "message" : null
+                    }
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Validation"
+              examples:
+                workspace-update-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C001",
+                      "status" : 400,
+                      "detail" : "잘못된 요청 형식입니다.",
+                      "instance" : "/api/v1/workspaces/1",
+                      "exception" : "BadRequestException",
+                      "timestamp" : "2026-02-12T15:43:52.307726"
+                    }
+  /api/v1/problems/number/{problemNumber}:
+    get:
+      tags:
+      - Problem
+      summary: 문제 번호로 조회
+      description: 백준 문제 번호로 문제를 조회합니다
+      operationId: problem-get-by-number
+      parameters:
+      - name: problemNumber
+        in: path
+        description: 백준 문제 번호
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-ProblemResponse"
+              examples:
+                problem-get-by-number:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "problemNumber" : 1000,
+                        "title" : "A+B",
+                        "tier" : "Bronze V",
+                        "timeLimit" : "2 초",
+                        "memoryLimit" : "128 MB",
+                        "description" : "두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.",
+                        "inputDescription" : "첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)",
+                        "outputDescription" : "첫째 줄에 A+B를 출력한다.",
+                        "url" : "https://www.acmicpc.net/problem/1000",
+                        "samples" : [ {
+                          "id" : 1,
+                          "sampleIndex" : 1,
+                          "input" : "1 2",
+                          "output" : "3"
+                        }, {
+                          "id" : 2,
+                          "sampleIndex" : 2,
+                          "input" : "3 4",
+                          "output" : "7"
+                        } ],
+                        "algorithmTags" : [ {
+                          "id" : 1,
+                          "name" : "수학"
+                        }, {
+                          "id" : 2,
+                          "name" : "구현"
+                        } ]
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 멤버 목록 조회
+      description: 워크스페이스 멤버 목록 조회
+      operationId: workspace-members
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-members-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A013",
+                      "status" : 403,
+                      "detail" : "워크스페이스에 소속된 멤버가 아닙니다.",
+                      "instance" : "/api/v1/workspaces/1/members",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.365511"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceMemberList"
+              examples:
+                workspace-members:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "items" : [ {
+                          "workspaceMemberId" : 1,
+                          "nickname" : "닉네임",
+                          "role" : "MEMBER"
+                        } ]
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/settings:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 설정 조회
+      description: 워크스페이스 설정 조회
+      operationId: workspace-settings
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-settings-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A014",
+                      "status" : 403,
+                      "detail" : "소유자만 이 작업을 수행할 수 있습니다.",
+                      "instance" : "/api/v1/workspaces/1/settings",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.650816"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceSettings"
+              examples:
+                workspace-settings:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "name" : "워크스페이스",
+                        "description" : "소개",
+                        "mmWebhookUrl" : "https://hook.example.com"
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members/invite:
+    post:
+      tags:
+      - Workspace
+      summary: 워크스페이스 멤버 초대
+      description: 워크스페이스 멤버 초대
+      operationId: workspace-invite
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/InviteWorkspaceMemberRequest"
+            examples:
+              workspace-invite-error:
+                value: |-
+                  {
+                    "email" : "invalid-email"
+                  }
+              workspace-invite:
+                value: |-
+                  {
+                    "email" : "invite@example.com"
+                  }
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Validation"
+              examples:
+                workspace-invite-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C001",
+                      "status" : 400,
+                      "detail" : "잘못된 요청 형식입니다.",
+                      "instance" : "/api/v1/workspaces/1/members/invite",
+                      "exception" : "MethodArgumentNotValidException",
+                      "timestamp" : "2026-02-12T15:43:52.46002",
+                      "fieldErrors" : [ {
+                        "field" : "email",
+                        "rejectedValue" : "invalid-email",
+                        "message" : "must be a well-formed email address"
+                      } ]
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                workspace-invite:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members/me:
+    get:
+      tags:
+      - Workspace
+      summary: 워크스페이스 멤버 조회
+      description: 워크스페이스 멤버 조회
+      operationId: workspace-member-me
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-member-me-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A013",
+                      "status" : 403,
+                      "detail" : "워크스페이스에 소속된 멤버가 아닙니다.",
+                      "instance" : "/api/v1/workspaces/1/members/me",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.609998"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceMemberResponse"
+              examples:
+                workspace-member-me:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "workspaceMemberId" : 1,
+                        "nickname" : "닉네임",
+                        "role" : "MEMBER"
+                      },
+                      "message" : null
+                    }
+    delete:
+      tags:
+      - Workspace
+      summary: 워크스페이스 탈퇴
+      description: 워크스페이스 탈퇴
+      operationId: workspace-leave
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-leave-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A012",
+                      "status" : 403,
+                      "detail" : "워크스페이스에 대한 권한이 없습니다.",
+                      "instance" : "/api/v1/workspaces/1/members/me",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.640134"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                workspace-leave:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}:
+    delete:
+      tags:
+      - Workspace
+      summary: 워크스페이스 멤버 추방
+      description: 워크스페이스 멤버 추방
+      operationId: workspace-member-remove
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      - name: workspaceMemberId
+        in: path
+        description: 워크스페이스 멤버 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Forbidden"
+              examples:
+                workspace-member-remove-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "A012",
+                      "status" : 403,
+                      "detail" : "워크스페이스에 대한 권한이 없습니다.",
+                      "instance" : "/api/v1/workspaces/1/members/2",
+                      "exception" : "ForbiddenException",
+                      "timestamp" : "2026-02-12T15:43:52.336805"
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                workspace-member-remove:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members/me/nickname:
+    patch:
+      tags:
+      - Workspace
+      summary: 워크스페이스 닉네임 수정
+      description: 워크스페이스 닉네임 수정
+      operationId: workspace-member-nickname-update
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/UpdateWorkspaceMemberNicknameRequest"
+            examples:
+              workspace-member-nickname-update-error:
+                value: |-
+                  {
+                    "nickname" : ""
+                  }
+              workspace-member-nickname-update:
+                value: |-
+                  {
+                    "nickname" : "새닉네임"
+                  }
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Validation"
+              examples:
+                workspace-member-nickname-update-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C001",
+                      "status" : 400,
+                      "detail" : "잘못된 요청 형식입니다.",
+                      "instance" : "/api/v1/workspaces/1/members/me/nickname",
+                      "exception" : "MethodArgumentNotValidException",
+                      "timestamp" : "2026-02-12T15:43:52.563218",
+                      "fieldErrors" : [ {
+                        "field" : "nickname",
+                        "rejectedValue" : "",
+                        "message" : "must not be blank"
+                      } ]
+                    }
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-WorkspaceMemberResponse"
+              examples:
+                workspace-member-nickname-update:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "workspaceMemberId" : 1,
+                        "nickname" : "새닉네임",
+                        "role" : "MEMBER"
+                      },
+                      "message" : null
+                    }
+  /api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}/role:
+    patch:
+      tags:
+      - Workspace
+      summary: 워크스페이스 멤버 권한 변경
+      description: 워크스페이스 멤버 권한을 변경합니다
+      operationId: workspace-member-role-update
+      parameters:
+      - name: workspaceId
+        in: path
+        description: 워크스페이스 ID
+        required: true
+        schema:
+          type: string
+      - name: workspaceMemberId
+        in: path
+        description: 워크스페이스 멤버 ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/UpdateWorkspaceMemberRoleRequest"
+            examples:
+              workspace-member-role-update:
+                value: |-
+                  {
+                    "role" : "MANAGER"
+                  }
+              workspace-member-role-update-error:
+                value: "{ }"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse-Void"
+              examples:
+                workspace-member-role-update:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "message" : null
+                    }
+        "400":
+          description: "400"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail-Validation"
+              examples:
+                workspace-member-role-update-error:
+                  value: |-
+                    {
+                      "type" : "/docs/index.html#error-code-list",
+                      "title" : "C001",
+                      "status" : 400,
+                      "detail" : "잘못된 요청 형식입니다.",
+                      "instance" : "/api/v1/workspaces/1/members/2/role",
+                      "exception" : "MethodArgumentNotValidException",
+                      "timestamp" : "2026-02-12T15:43:52.504873",
+                      "fieldErrors" : [ {
+                        "field" : "role",
+                        "rejectedValue" : null,
+                        "message" : "must not be null"
+                      } ]
+                    }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: "로그인 후 받은 accessToken을 입력하세요"
+  schemas:
+    ProblemDetail-Forbidden:
+      title: ProblemDetail-Forbidden
+      required:
+      - detail
+      - exception
+      - status
+      - timestamp
+      - title
+      - type
+      type: object
+      properties:
+        exception:
+          type: string
+          description: 예외 클래스명
+        instance:
+          type: string
+          description: 오류 인스턴스
+          nullable: true
+        detail:
+          type: string
+          description: 오류 상세 메시지
+        title:
+          type: string
+          description: 에러 코드
+        type:
+          type: string
+          description: 오류 문서 URI
+        timestamp:
+          type: string
+          description: 발생 시각
+        status:
+          type: number
+          description: HTTP 상태 코드
+    RefreshRequest:
+      title: RefreshRequest
+      required:
+      - refreshToken
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+    UpdateWorkspaceMemberRoleRequest:
+      title: UpdateWorkspaceMemberRoleRequest
+      required:
+      - role
+      type: object
+      properties:
+        role:
+          type: string
+          description: 변경할 권한
+    ApiResponse-WorkspaceSettings:
+      title: ApiResponse-WorkspaceSettings
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - id
+          - name
+          type: object
+          properties:
+            mmWebhookUrl:
+              type: string
+              description: MM 웹훅 URL
+              nullable: true
+            name:
+              type: string
+              description: 워크스페이스 이름
+            description:
+              type: string
+              description: 워크스페이스 설명
+              nullable: true
+            id:
+              type: number
+              description: 워크스페이스 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    UserUpdateRequest:
+      title: UserUpdateRequest
+      type: object
+      properties:
+        name:
+          type: string
+          description: 수정할 이름 (30자 이내)
+          nullable: true
+        profileImageUrl:
+          type: string
+          description: 수정할 프로필 이미지 URL
+          nullable: true
+    ApiResponse-AuthTokenResponse:
+      title: ApiResponse-AuthTokenResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          - refreshToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 액세스 토큰
+            refreshToken:
+              type: string
+              description: 새 리프레시 토큰
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ApiResponse-WorkspaceList:
+      title: ApiResponse-WorkspaceList
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - items
+          type: object
+          properties:
+            items:
+              type: array
+              description: 워크스페이스 목록
+              items:
+                required:
+                - id
+                - name
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: 워크스페이스 이름
+                  description:
+                    type: string
+                    description: 워크스페이스 설명
+                    nullable: true
+                  id:
+                    type: number
+                    description: 워크스페이스 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ProblemDetail-NotFound:
+      title: ProblemDetail-NotFound
+      required:
+      - detail
+      - exception
+      - status
+      - timestamp
+      - title
+      - type
+      type: object
+      properties:
+        exception:
+          type: string
+          description: 예외 클래스명
+        instance:
+          type: string
+          description: 오류 인스턴스
+          nullable: true
+        detail:
+          type: string
+          description: 오류 상세 메시지
+        title:
+          type: string
+          description: 에러 코드
+        type:
+          type: string
+          description: 오류 문서 URI
+        timestamp:
+          type: string
+          description: 발생 시각
+        status:
+          type: number
+          description: HTTP 상태 코드
+    CreateWorkspaceRequest:
+      title: CreateWorkspaceRequest
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: 워크스페이스 이름
+        description:
+          type: string
+          description: 워크스페이스 설명
+          nullable: true
+    SignupRequest:
+      title: SignupRequest
+      required:
+      - email
+      - name
+      - password
+      type: object
+      properties:
+        password:
+          type: string
+          description: 비밀번호
+        name:
+          type: string
+          description: 이름
+        email:
+          type: string
+          description: 이메일
+    ApiResponse-Void:
+      title: ApiResponse-Void
+      required:
+      - success
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ProblemDetail-Validation:
+      title: ProblemDetail-Validation
+      required:
+      - detail
+      - exception
+      - fieldErrors
+      - status
+      - timestamp
+      - title
+      - type
+      type: object
+      properties:
+        exception:
+          type: string
+          description: 예외 클래스명
+        fieldErrors:
+          type: array
+          description: 필드 오류 목록
+          items:
+            required:
+            - field
+            - message
+            type: object
+            properties:
+              field:
+                type: string
+                description: 필드명
+              message:
+                type: string
+                description: 오류 메시지
+              rejectedValue:
+                type: object
+                description: 거절된 값
+                nullable: true
+        instance:
+          type: string
+          description: 오류 인스턴스
+          nullable: true
+        detail:
+          type: string
+          description: 오류 상세 메시지
+        title:
+          type: string
+          description: 에러 코드
+        type:
+          type: string
+          description: 오류 문서 URI
+        timestamp:
+          type: string
+          description: 발생 시각
+        status:
+          type: number
+          description: HTTP 상태 코드
+    LoginRequest:
+      title: LoginRequest
+      required:
+      - email
+      - password
+      type: object
+      properties:
+        password:
+          type: string
+          description: 비밀번호
+        email:
+          type: string
+          description: 이메일
+    ApiResponse-UserResponse:
+      title: ApiResponse-UserResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - email
+          - id
+          - name
+          - provider
+          type: object
+          properties:
+            provider:
+              type: string
+              description: "인증 제공자 (GOOGLE, KAKAO, LOCAL)"
+            name:
+              type: string
+              description: 이름
+            id:
+              type: number
+              description: 유저 ID
+            profileImageUrl:
+              type: string
+              description: 프로필 이미지 URL
+              nullable: true
+            email:
+              type: string
+              description: 이메일
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    UpdateWorkspaceMemberNicknameRequest:
+      title: UpdateWorkspaceMemberNicknameRequest
+      required:
+      - nickname
+      type: object
+      properties:
+        nickname:
+          type: string
+          description: 닉네임
+    ApiResponse-WorkspaceExplore:
+      title: ApiResponse-WorkspaceExplore
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - content
+          - page
+          type: object
+          properties:
+            page:
+              required:
+              - first
+              - last
+              - page
+              - size
+              - totalElements
+              - totalPages
+              type: object
+              properties:
+                last:
+                  type: boolean
+                  description: 마지막 페이지 여부
+                size:
+                  type: number
+                  description: 페이지 크기
+                totalPages:
+                  type: number
+                  description: 전체 페이지 수
+                page:
+                  type: number
+                  description: 페이지 번호
+                first:
+                  type: boolean
+                  description: 첫 페이지 여부
+                totalElements:
+                  type: number
+                  description: 전체 요소 수
+              description: 페이지 정보
+            content:
+              type: array
+              description: 워크스페이스 목록
+              items:
+                required:
+                - id
+                - name
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: 워크스페이스 이름
+                  description:
+                    type: string
+                    description: 워크스페이스 설명
+                    nullable: true
+                  id:
+                    type: number
+                    description: 워크스페이스 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ProblemDetail-MissingParameter:
+      title: ProblemDetail-MissingParameter
+      required:
+      - detail
+      - exception
+      - status
+      - timestamp
+      - title
+      - type
+      type: object
+      properties:
+        exception:
+          type: string
+          description: 예외 클래스명
+        instance:
+          type: string
+          description: 오류 인스턴스
+          nullable: true
+        detail:
+          type: string
+          description: 오류 상세 메시지
+        title:
+          type: string
+          description: 에러 코드
+        type:
+          type: string
+          description: 오류 문서 URI
+        timestamp:
+          type: string
+          description: 발생 시각
+        status:
+          type: number
+          description: HTTP 상태 코드
+    ApiResponse-WorkspaceMemberResponse:
+      title: ApiResponse-WorkspaceMemberResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - nickname
+          - role
+          - workspaceMemberId
+          type: object
+          properties:
+            role:
+              type: string
+              description: 권한
+            nickname:
+              type: string
+              description: 닉네임
+            workspaceMemberId:
+              type: number
+              description: 워크스페이스 멤버 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    InviteWorkspaceMemberRequest:
+      title: InviteWorkspaceMemberRequest
+      required:
+      - email
+      type: object
+      properties:
+        email:
+          type: string
+          description: 초대할 이메일
+    ApiResponse-WorkspaceMemberList:
+      title: ApiResponse-WorkspaceMemberList
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - items
+          type: object
+          properties:
+            items:
+              type: array
+              description: 멤버 목록
+              items:
+                required:
+                - nickname
+                - role
+                - workspaceMemberId
+                type: object
+                properties:
+                  role:
+                    type: string
+                    description: 권한
+                  nickname:
+                    type: string
+                    description: 닉네임
+                  workspaceMemberId:
+                    type: number
+                    description: 워크스페이스 멤버 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    UpdateWorkspaceRequest:
+      title: UpdateWorkspaceRequest
+      type: object
+      properties:
+        mmWebhookUrl:
+          type: string
+          description: MM 웹훅 URL
+          nullable: true
+        name:
+          type: string
+          description: 워크스페이스 이름
+          nullable: true
+        description:
+          type: string
+          description: 워크스페이스 설명
+          nullable: true
+    ApiResponse-WorkspaceSearch:
+      title: ApiResponse-WorkspaceSearch
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - content
+          - page
+          type: object
+          properties:
+            page:
+              required:
+              - first
+              - last
+              - page
+              - size
+              - totalElements
+              - totalPages
+              type: object
+              properties:
+                last:
+                  type: boolean
+                  description: 마지막 페이지 여부
+                size:
+                  type: number
+                  description: 페이지 크기
+                totalPages:
+                  type: number
+                  description: 전체 페이지 수
+                page:
+                  type: number
+                  description: 페이지 번호
+                first:
+                  type: boolean
+                  description: 첫 페이지 여부
+                totalElements:
+                  type: number
+                  description: 전체 요소 수
+              description: 페이지 정보
+            content:
+              type: array
+              description: 워크스페이스 목록
+              items:
+                required:
+                - id
+                - name
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: 워크스페이스 이름
+                  description:
+                    type: string
+                    description: 워크스페이스 설명
+                    nullable: true
+                  id:
+                    type: number
+                    description: 워크스페이스 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ProblemDetail-InvalidParameter:
+      title: ProblemDetail-InvalidParameter
+      required:
+      - detail
+      - exception
+      - status
+      - timestamp
+      - title
+      - type
+      type: object
+      properties:
+        exception:
+          type: string
+          description: 예외 클래스명
+        instance:
+          type: string
+          description: 오류 인스턴스
+          nullable: true
+        detail:
+          type: string
+          description: 오류 상세 메시지
+        title:
+          type: string
+          description: 에러 코드
+        type:
+          type: string
+          description: 오류 문서 URI
+        timestamp:
+          type: string
+          description: 발생 시각
+        status:
+          type: number
+          description: HTTP 상태 코드
+    ApiResponse-WorkspaceResponse:
+      title: ApiResponse-WorkspaceResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - id
+          - name
+          type: object
+          properties:
+            name:
+              type: string
+              description: 워크스페이스 이름
+            description:
+              type: string
+              description: 워크스페이스 설명
+              nullable: true
+            id:
+              type: number
+              description: 워크스페이스 ID
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ApiResponse-ProblemResponse:
+      title: ApiResponse-ProblemResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - algorithmTags
+          - id
+          - problemNumber
+          - samples
+          - title
+          type: object
+          properties:
+            timeLimit:
+              type: string
+              description: 시간 제한
+              nullable: true
+            inputDescription:
+              type: string
+              description: 입력 설명
+              nullable: true
+            algorithmTags:
+              type: array
+              description: 알고리즘 태그 목록
+              items:
+                required:
+                - id
+                - name
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: 태그 이름
+                  id:
+                    type: number
+                    description: 태그 ID
+            tier:
+              type: string
+              description: 난이도
+              nullable: true
+            problemNumber:
+              type: number
+              description: 백준 문제 번호
+            description:
+              type: string
+              description: 문제 설명
+              nullable: true
+            memoryLimit:
+              type: string
+              description: 메모리 제한
+              nullable: true
+            id:
+              type: number
+              description: 문제 ID
+            title:
+              type: string
+              description: 문제 제목
+            outputDescription:
+              type: string
+              description: 출력 설명
+              nullable: true
+            samples:
+              type: array
+              description: 입출력 예제 목록
+              items:
+                required:
+                - id
+                - sampleIndex
+                type: object
+                properties:
+                  output:
+                    type: string
+                    description: 예제 출력
+                    nullable: true
+                  input:
+                    type: string
+                    description: 예제 입력
+                    nullable: true
+                  sampleIndex:
+                    type: number
+                    description: 예제 번호
+                  id:
+                    type: number
+                    description: 예제 ID
+            url:
+              type: string
+              description: 백준 문제 URL
+              nullable: true
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ProblemIngestRequest:
+      title: ProblemIngestRequest
+      required:
+      - problemNum
+      - title
+      type: object
+      properties:
+        timeLimit:
+          type: string
+          description: 시간 제한
+          nullable: true
+        tier:
+          type: string
+          description: 난이도
+          nullable: true
+        problemOutput:
+          type: string
+          description: 출력 설명
+          nullable: true
+        memoryLimit:
+          type: string
+          description: 메모리 제한
+          nullable: true
+        problemNum:
+          type: number
+          description: 백준 문제 번호
+        problemInput:
+          type: string
+          description: 입력 설명
+          nullable: true
+        problemDesc:
+          type: string
+          description: 문제 설명
+          nullable: true
+        title:
+          type: string
+          description: 문제 제목
+        samples:
+          type: array
+          description: 입출력 예제 목록
+          items:
+            required:
+            - sampleIndex
+            type: object
+            properties:
+              output:
+                type: string
+                description: 예제 출력
+                nullable: true
+              input:
+                type: string
+                description: 예제 입력
+                nullable: true
+              sampleIndex:
+                type: number
+                description: 예제 번호
+        url:
+          type: string
+          description: 백준 문제 URL
+          nullable: true
+        tags:
+          type: array
+          description: 알고리즘 태그 목록
+          items:
+            required:
+            - name
+            type: object
+            properties:
+              name:
+                type: string
+                description: 태그 이름

--- a/src/main/resources/static/swagger/swagger-ui.html
+++ b/src/main/resources/static/swagger/swagger-ui.html
@@ -40,6 +40,7 @@
             url: "openapi3.yaml",
             dom_id: '#swagger-ui',
             deepLinking: true,
+            persistAuthorization: true,
             presets: [
                 SwaggerUIBundle.presets.apis,
                 SwaggerUIStandalonePreset

--- a/src/test/java/com/ujax/application/auth/AuthServiceTest.java
+++ b/src/test/java/com/ujax/application/auth/AuthServiceTest.java
@@ -1,0 +1,169 @@
+package com.ujax.application.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.domain.auth.RefreshTokenRepository;
+import com.ujax.domain.user.AuthProvider;
+import com.ujax.domain.user.User;
+import com.ujax.domain.user.UserRepository;
+import com.ujax.global.exception.common.BadRequestException;
+import com.ujax.global.exception.common.ConflictException;
+import com.ujax.global.exception.common.UnauthorizedException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthServiceTest {
+
+	@Autowired
+	private AuthService authService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@BeforeEach
+	void setUp() {
+		refreshTokenRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@Nested
+	@DisplayName("회원가입")
+	class Signup {
+
+		@Test
+		@DisplayName("새 사용자를 등록하고 토큰을 반환한다")
+		void signup_Success() {
+			// when
+			AuthTokenResponse response = authService.signup("new@example.com", "password123", "새유저");
+
+			// then
+			assertThat(response).extracting("accessToken", "refreshToken")
+				.doesNotContainNull();
+			assertThat(userRepository.findByEmail("new@example.com")).isPresent();
+		}
+
+		@Test
+		@DisplayName("비밀번호가 규칙에 맞지 않으면 오류가 발생한다")
+		void signup_InvalidPassword() {
+			// when & then
+			assertThatThrownBy(() -> authService.signup("new@example.com", "short1", "유저"))
+				.isInstanceOf(BadRequestException.class);
+		}
+
+		@Test
+		@DisplayName("이미 존재하는 이메일로 가입하면 오류가 발생한다")
+		void signup_DuplicateEmail() {
+			// given
+			authService.signup("existing@example.com", "password123", "기존유저");
+
+			// when & then
+			assertThatThrownBy(() -> authService.signup("existing@example.com", "password456", "새유저"))
+				.isInstanceOf(ConflictException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("로그인")
+	class Login {
+
+		@Test
+		@DisplayName("올바른 자격 증명으로 로그인한다")
+		void login_Success() {
+			// given
+			authService.signup("user@example.com", "password123", "유저");
+
+			// when
+			AuthTokenResponse response = authService.login("user@example.com", "password123");
+
+			// then
+			assertThat(response).extracting("accessToken", "refreshToken")
+				.doesNotContainNull();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이메일로 로그인하면 오류가 발생한다")
+		void login_UserNotFound() {
+			// when & then
+			assertThatThrownBy(() -> authService.login("nonexistent@example.com", "password"))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+
+		@Test
+		@DisplayName("잘못된 비밀번호로 로그인하면 오류가 발생한다")
+		void login_WrongPassword() {
+			// given
+			authService.signup("user@example.com", "password123", "유저");
+
+			// when & then
+			assertThatThrownBy(() -> authService.login("user@example.com", "wrongpassword"))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+
+		@Test
+		@DisplayName("OAuth 사용자가 자체 로그인을 시도하면 오류가 발생한다")
+		void login_OAuthUser() {
+			// given
+			User oauthUser = User.createOAuthUser("oauth@example.com", "OAuth유저", null,
+				AuthProvider.GOOGLE, "google123");
+			userRepository.save(oauthUser);
+
+			// when & then
+			assertThatThrownBy(() -> authService.login("oauth@example.com", "password"))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("토큰 갱신")
+	class Refresh {
+
+		@Test
+		@DisplayName("유효한 리프레시 토큰으로 새 토큰을 발급받는다")
+		void refresh_Success() {
+			// given
+			AuthTokenResponse tokens = authService.signup("user@example.com", "password123", "유저");
+
+			// when
+			AuthTokenResponse newTokens = authService.refresh(tokens.refreshToken());
+
+			// then
+			assertThat(newTokens).extracting("accessToken", "refreshToken")
+				.doesNotContainNull();
+			assertThat(newTokens.refreshToken()).isNotEqualTo(tokens.refreshToken());
+		}
+
+		@Test
+		@DisplayName("유효하지 않은 리프레시 토큰으로 갱신하면 오류가 발생한다")
+		void refresh_InvalidToken() {
+			// when & then
+			assertThatThrownBy(() -> authService.refresh("invalidToken"))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+	}
+
+	@Test
+	@DisplayName("로그아웃하면 리프레시 토큰이 해지된다")
+	void logout() {
+		// given
+		AuthTokenResponse tokens = authService.signup("user@example.com", "password123", "유저");
+
+		// when
+		authService.logout(tokens.refreshToken());
+
+		// then
+		assertThatThrownBy(() -> authService.refresh(tokens.refreshToken()))
+			.isInstanceOf(UnauthorizedException.class);
+	}
+}

--- a/src/test/java/com/ujax/application/user/UserServiceTest.java
+++ b/src/test/java/com/ujax/application/user/UserServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ujax.application.user.dto.response.UserResponse;
+import com.ujax.domain.auth.RefreshTokenRepository;
 import com.ujax.domain.user.AuthProvider;
 import com.ujax.domain.user.User;
 import com.ujax.domain.user.UserRepository;
@@ -26,8 +27,12 @@ class UserServiceTest {
 	@Autowired
 	private UserRepository userRepository;
 
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
 	@BeforeEach
 	void tearDown() {
+		refreshTokenRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 	}
 

--- a/src/test/java/com/ujax/application/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/com/ujax/application/workspace/WorkspaceServiceTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.ujax.application.workspace.dto.response.WorkspaceSettingsResponse;
+import com.ujax.domain.auth.RefreshTokenRepository;
+import com.ujax.domain.user.Password;
 import com.ujax.domain.user.User;
 import com.ujax.domain.user.UserRepository;
 import com.ujax.domain.workspace.Workspace;
@@ -42,13 +44,17 @@ class WorkspaceServiceTest {
 	@Autowired
 	private UserRepository userRepository;
 
-	@MockBean
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@MockitoBean
 	private WorkspaceInviteMailer workspaceInviteMailer;
 
 	@BeforeEach
 	void setUp() {
 		workspaceMemberRepository.deleteAllInBatch();
 		workspaceRepository.deleteAllInBatch();
+		refreshTokenRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 	}
 
@@ -60,7 +66,7 @@ class WorkspaceServiceTest {
 		@DisplayName("워크스페이스 생성 시 소유자 멤버가 생성된다")
 		void createWorkspaceCreatesOwner() {
 			// given
-			User user = userRepository.save(User.createLocalUser("owner@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("owner@example.com", Password.ofEncoded("password"), "유저"));
 
 			// when
 			Long workspaceId = workspaceService.createWorkspace("워크스페이스", "소개", user.getId()).id();
@@ -78,7 +84,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름이 중복되면 오류가 발생한다")
 		void createWorkspaceDuplicateName() {
 			// given
-			User user = userRepository.save(User.createLocalUser("dup@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("dup@example.com", Password.ofEncoded("password"), "유저"));
 			workspaceRepository.save(Workspace.create("중복", "소개"));
 
 			// when & then
@@ -91,7 +97,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름이 비어 있으면 오류가 발생한다")
 		void createWorkspaceInvalidName() {
 			// given
-			User user = userRepository.save(User.createLocalUser("blank@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("blank@example.com", Password.ofEncoded("password"), "유저"));
 
 			// when & then
 			assertThatThrownBy(() -> workspaceService.createWorkspace(" ", "소개", user.getId()))
@@ -103,7 +109,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름이 너무 길면 오류가 발생한다")
 		void createWorkspaceNameTooLong() {
 			// given
-			User user = userRepository.save(User.createLocalUser("longname@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("longname@example.com", Password.ofEncoded("password"), "유저"));
 			String longName = "a".repeat(51);
 
 			// when & then
@@ -116,7 +122,7 @@ class WorkspaceServiceTest {
 		@DisplayName("설명이 너무 길면 오류가 발생한다")
 		void createWorkspaceInvalidDescription() {
 			// given
-			User user = userRepository.save(User.createLocalUser("desc@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("desc@example.com", Password.ofEncoded("password"), "유저"));
 			String longDescription = "a".repeat(201);
 
 			// when & then
@@ -143,8 +149,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 아니면 수정할 수 없다")
 		void updateWorkspaceForbidden() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner2@example.com", "password", "유저"));
-			User memberUser = userRepository.save(User.createLocalUser("member@example.com", "password", "멤버"));
+			User owner = userRepository.save(User.createLocalUser("owner2@example.com", Password.ofEncoded("password"), "유저"));
+			User memberUser = userRepository.save(User.createLocalUser("member@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -165,7 +171,7 @@ class WorkspaceServiceTest {
 		@DisplayName("워크스페이스가 없으면 오류가 발생한다")
 		void updateWorkspaceNotFound() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-missing@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-missing@example.com", Password.ofEncoded("password"), "유저"));
 
 			// when & then
 			assertThatThrownBy(() -> workspaceService.updateWorkspace(
@@ -183,7 +189,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름과 소개를 수정할 수 있다")
 		void updateWorkspace() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-update@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-update@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -200,7 +206,7 @@ class WorkspaceServiceTest {
 		@DisplayName("웹훅만 수정할 수 있다")
 		void updateWorkspaceOnlyWebhook() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-webhook@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-webhook@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -217,7 +223,7 @@ class WorkspaceServiceTest {
 		@DisplayName("수정 값이 모두 없으면 오류가 발생한다")
 		void updateWorkspaceAllNull() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-null@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-null@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -231,7 +237,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름이 중복되면 오류가 발생한다")
 		void updateWorkspaceDuplicateName() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-dup@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-dup@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceRepository.save(Workspace.create("중복", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
@@ -252,7 +258,7 @@ class WorkspaceServiceTest {
 		@DisplayName("이름이 비어 있으면 오류가 발생한다")
 		void updateWorkspaceInvalidName() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-blank@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-blank@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -272,7 +278,7 @@ class WorkspaceServiceTest {
 		@DisplayName("설명이 너무 길면 오류가 발생한다")
 		void updateWorkspaceInvalidDescription() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-desc@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-desc@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			String longDescription = "a".repeat(201);
@@ -386,8 +392,8 @@ class WorkspaceServiceTest {
 		@DisplayName("워크스페이스 멤버 목록을 조회한다")
 		void listWorkspaceMembers() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-list@example.com", "password", "유저"));
-			User memberUser = userRepository.save(User.createLocalUser("member-list@example.com", "password", "멤버"));
+			User owner = userRepository.save(User.createLocalUser("owner-list@example.com", Password.ofEncoded("password"), "유저"));
+			User memberUser = userRepository.save(User.createLocalUser("member-list@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -418,7 +424,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버가 아니면 목록을 조회할 수 없다")
 		void listWorkspaceMembersForbidden() {
 			// given
-			User outsider = userRepository.save(User.createLocalUser("outsider@example.com", "password", "유저"));
+			User outsider = userRepository.save(User.createLocalUser("outsider@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 
 			// when & then
@@ -436,7 +442,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버는 자신의 정보를 조회할 수 있다")
 		void getMyWorkspaceMember() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-self@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-self@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember member = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER)
@@ -454,7 +460,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버가 아니면 조회할 수 없다")
 		void getMyWorkspaceMemberForbidden() {
 			// given
-			User outsider = userRepository.save(User.createLocalUser("outsider-self@example.com", "password", "외부"));
+			User outsider = userRepository.save(User.createLocalUser("outsider-self@example.com", Password.ofEncoded("password"), "외부"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 
 			// when & then
@@ -472,7 +478,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버는 닉네임을 수정할 수 있다")
 		void updateNickname() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-nick@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-nick@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember member = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.MEMBER)
@@ -491,7 +497,7 @@ class WorkspaceServiceTest {
 		@DisplayName("닉네임이 비어 있으면 오류가 발생한다")
 		void updateNicknameInvalid() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-nick2@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-nick2@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.MEMBER));
 
@@ -505,7 +511,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버가 아니면 닉네임을 수정할 수 없다")
 		void updateNicknameForbidden() {
 			// given
-			User outsider = userRepository.save(User.createLocalUser("outsider-nick@example.com", "password", "외부"));
+			User outsider = userRepository.save(User.createLocalUser("outsider-nick@example.com", Password.ofEncoded("password"), "외부"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 
 			// when & then
@@ -523,8 +529,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 다른 멤버를 소유자로 변경하면 자신은 매니저가 된다")
 		void transferOwner() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-role@example.com", "password", "소유자"));
-			User memberUser = userRepository.save(User.createLocalUser("member-role@example.com", "password", "멤버"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-role@example.com", Password.ofEncoded("password"), "소유자"));
+			User memberUser = userRepository.save(User.createLocalUser("member-role@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember owner = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER)
@@ -552,9 +558,9 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 아니면 권한을 변경할 수 없다")
 		void updateRoleForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-role2@example.com", "password", "소유자"));
-			User memberUser = userRepository.save(User.createLocalUser("member-role2@example.com", "password", "멤버"));
-			User targetUser = userRepository.save(User.createLocalUser("target-role2@example.com", "password", "대상"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-role2@example.com", Password.ofEncoded("password"), "소유자"));
+			User memberUser = userRepository.save(User.createLocalUser("member-role2@example.com", Password.ofEncoded("password"), "멤버"));
+			User targetUser = userRepository.save(User.createLocalUser("target-role2@example.com", Password.ofEncoded("password"), "대상"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -577,8 +583,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자 권한은 변경할 수 없다")
 		void updateRoleOwnerForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-role3@example.com", "password", "소유자"));
-			User memberUser = userRepository.save(User.createLocalUser("member-role3@example.com", "password", "멤버"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-role3@example.com", Password.ofEncoded("password"), "소유자"));
+			User memberUser = userRepository.save(User.createLocalUser("member-role3@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember owner = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER)
@@ -600,7 +606,7 @@ class WorkspaceServiceTest {
 		@DisplayName("대상 멤버가 없으면 오류가 발생한다")
 		void updateRoleMemberNotFound() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-role4@example.com", "password", "소유자"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-role4@example.com", Password.ofEncoded("password"), "소유자"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 
@@ -624,9 +630,9 @@ class WorkspaceServiceTest {
 		@DisplayName("매니저는 멤버를 추방할 수 있다")
 		void removeByManager() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove@example.com", "password", "소유자"));
-			User managerUser = userRepository.save(User.createLocalUser("manager-remove@example.com", "password", "매니저"));
-			User memberUser = userRepository.save(User.createLocalUser("member-remove@example.com", "password", "멤버"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove@example.com", Password.ofEncoded("password"), "소유자"));
+			User managerUser = userRepository.save(User.createLocalUser("manager-remove@example.com", Password.ofEncoded("password"), "매니저"));
+			User memberUser = userRepository.save(User.createLocalUser("member-remove@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, managerUser, WorkspaceMemberRole.MANAGER));
@@ -646,9 +652,9 @@ class WorkspaceServiceTest {
 		@DisplayName("매니저는 매니저를 추방할 수 없다")
 		void removeManagerForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove2@example.com", "password", "소유자"));
-			User managerUser = userRepository.save(User.createLocalUser("manager-remove2@example.com", "password", "매니저"));
-			User targetUser = userRepository.save(User.createLocalUser("target-remove@example.com", "password", "매니저2"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove2@example.com", Password.ofEncoded("password"), "소유자"));
+			User managerUser = userRepository.save(User.createLocalUser("manager-remove2@example.com", Password.ofEncoded("password"), "매니저"));
+			User targetUser = userRepository.save(User.createLocalUser("target-remove@example.com", Password.ofEncoded("password"), "매니저2"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, managerUser, WorkspaceMemberRole.MANAGER));
@@ -666,8 +672,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자는 추방할 수 없다")
 		void removeOwnerForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove3@example.com", "password", "소유자"));
-			User managerUser = userRepository.save(User.createLocalUser("manager-remove3@example.com", "password", "매니저"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove3@example.com", Password.ofEncoded("password"), "소유자"));
+			User managerUser = userRepository.save(User.createLocalUser("manager-remove3@example.com", Password.ofEncoded("password"), "매니저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember owner = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER)
@@ -684,7 +690,7 @@ class WorkspaceServiceTest {
 		@DisplayName("자기 자신은 추방할 수 없다")
 		void removeSelfForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove4@example.com", "password", "소유자"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove4@example.com", Password.ofEncoded("password"), "소유자"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			WorkspaceMember owner = workspaceMemberRepository.save(
 				WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER)
@@ -700,9 +706,9 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버가 아니면 추방할 수 없다")
 		void removeMemberForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove5@example.com", "password", "소유자"));
-			User outsider = userRepository.save(User.createLocalUser("outsider-remove@example.com", "password", "외부"));
-			User memberUser = userRepository.save(User.createLocalUser("member-remove5@example.com", "password", "멤버"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove5@example.com", Password.ofEncoded("password"), "소유자"));
+			User outsider = userRepository.save(User.createLocalUser("outsider-remove@example.com", Password.ofEncoded("password"), "외부"));
+			User memberUser = userRepository.save(User.createLocalUser("member-remove5@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			WorkspaceMember member = workspaceMemberRepository.save(
@@ -719,9 +725,9 @@ class WorkspaceServiceTest {
 		@DisplayName("일반 멤버는 다른 멤버를 추방할 수 없다")
 		void removeByMemberForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove6@example.com", "password", "소유자"));
-			User memberUser = userRepository.save(User.createLocalUser("member-remove6@example.com", "password", "멤버"));
-			User targetUser = userRepository.save(User.createLocalUser("target-remove6@example.com", "password", "대상"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove6@example.com", Password.ofEncoded("password"), "소유자"));
+			User memberUser = userRepository.save(User.createLocalUser("member-remove6@example.com", Password.ofEncoded("password"), "멤버"));
+			User targetUser = userRepository.save(User.createLocalUser("target-remove6@example.com", Password.ofEncoded("password"), "대상"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -739,7 +745,7 @@ class WorkspaceServiceTest {
 		@DisplayName("대상 멤버가 없으면 오류가 발생한다")
 		void removeMemberNotFound() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-remove6@example.com", "password", "소유자"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-remove6@example.com", Password.ofEncoded("password"), "소유자"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 
@@ -758,8 +764,8 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버는 워크스페이스를 탈퇴할 수 있다")
 		void leaveWorkspace() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-leave@example.com", "password", "소유자"));
-			User memberUser = userRepository.save(User.createLocalUser("member-leave@example.com", "password", "멤버"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-leave@example.com", Password.ofEncoded("password"), "소유자"));
+			User memberUser = userRepository.save(User.createLocalUser("member-leave@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 			WorkspaceMember member = workspaceMemberRepository.save(
@@ -778,7 +784,7 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자는 워크스페이스를 탈퇴할 수 없다")
 		void leaveWorkspaceOwnerForbidden() {
 			// given
-			User ownerUser = userRepository.save(User.createLocalUser("owner-leave2@example.com", "password", "소유자"));
+			User ownerUser = userRepository.save(User.createLocalUser("owner-leave2@example.com", Password.ofEncoded("password"), "소유자"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, ownerUser, WorkspaceMemberRole.OWNER));
 
@@ -792,7 +798,7 @@ class WorkspaceServiceTest {
 		@DisplayName("멤버가 아니면 탈퇴할 수 없다")
 		void leaveWorkspaceForbidden() {
 			// given
-			User outsider = userRepository.save(User.createLocalUser("outsider-leave@example.com", "password", "외부"));
+			User outsider = userRepository.save(User.createLocalUser("outsider-leave@example.com", Password.ofEncoded("password"), "외부"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 
 			// when & then
@@ -810,7 +816,7 @@ class WorkspaceServiceTest {
 		@DisplayName("유저가 속한 워크스페이스 목록을 조회한다")
 		void listMyWorkspaces() {
 			// given
-			User user = userRepository.save(User.createLocalUser("mine@example.com", "password", "유저"));
+			User user = userRepository.save(User.createLocalUser("mine@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER));
 
@@ -831,7 +837,7 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자는 설정 정보를 조회할 수 있다")
 		void getWorkspaceSettings() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner3@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner3@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceService.updateWorkspace(workspace.getId(), owner.getId(), null, null, "https://hook.example.com");
@@ -848,8 +854,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 아니면 설정을 조회할 수 없다")
 		void getWorkspaceSettingsForbidden() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner3-2@example.com", "password", "유저"));
-			User memberUser = userRepository.save(User.createLocalUser("member3-2@example.com", "password", "멤버"));
+			User owner = userRepository.save(User.createLocalUser("owner3-2@example.com", Password.ofEncoded("password"), "유저"));
+			User memberUser = userRepository.save(User.createLocalUser("member3-2@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -864,7 +870,7 @@ class WorkspaceServiceTest {
 		@DisplayName("워크스페이스가 없으면 오류가 발생한다")
 		void getWorkspaceSettingsNotFound() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner3-3@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner3-3@example.com", Password.ofEncoded("password"), "유저"));
 
 			// when & then
 			assertThatThrownBy(() -> workspaceService.getWorkspaceSettings(999L, owner.getId()))
@@ -881,7 +887,7 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자는 워크스페이스를 삭제할 수 있다")
 		void deleteWorkspace() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-delete@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-delete@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -897,8 +903,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 아니면 삭제할 수 없다")
 		void deleteWorkspaceForbidden() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-delete2@example.com", "password", "유저"));
-			User memberUser = userRepository.save(User.createLocalUser("member-delete@example.com", "password", "멤버"));
+			User owner = userRepository.save(User.createLocalUser("owner-delete2@example.com", Password.ofEncoded("password"), "유저"));
+			User memberUser = userRepository.save(User.createLocalUser("member-delete@example.com", Password.ofEncoded("password"), "멤버"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -913,7 +919,7 @@ class WorkspaceServiceTest {
 		@DisplayName("워크스페이스가 없으면 오류가 발생한다")
 		void deleteWorkspaceNotFound() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner-delete3@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner-delete3@example.com", Password.ofEncoded("password"), "유저"));
 
 			// when & then
 			assertThatThrownBy(() -> workspaceService.deleteWorkspace(999L, owner.getId()))
@@ -930,8 +936,8 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자는 이메일로 멤버를 초대할 수 있다")
 		void inviteWorkspaceMember() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner4@example.com", "password", "유저"));
-			User target = userRepository.save(User.createLocalUser("invite@example.com", "password", "초대"));
+			User owner = userRepository.save(User.createLocalUser("owner4@example.com", Password.ofEncoded("password"), "유저"));
+			User target = userRepository.save(User.createLocalUser("invite@example.com", Password.ofEncoded("password"), "초대"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 
@@ -949,9 +955,9 @@ class WorkspaceServiceTest {
 		@DisplayName("소유자가 아니면 초대할 수 없다")
 		void inviteWorkspaceMemberForbidden() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner5@example.com", "password", "유저"));
-			User memberUser = userRepository.save(User.createLocalUser("member2@example.com", "password", "멤버"));
-			User target = userRepository.save(User.createLocalUser("invite2@example.com", "password", "초대"));
+			User owner = userRepository.save(User.createLocalUser("owner5@example.com", Password.ofEncoded("password"), "유저"));
+			User memberUser = userRepository.save(User.createLocalUser("member2@example.com", Password.ofEncoded("password"), "멤버"));
+			User target = userRepository.save(User.createLocalUser("invite2@example.com", Password.ofEncoded("password"), "초대"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, memberUser, WorkspaceMemberRole.MEMBER));
@@ -970,8 +976,8 @@ class WorkspaceServiceTest {
 		@DisplayName("이미 참여한 멤버면 오류가 발생한다")
 		void inviteWorkspaceMemberDuplicate() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner6@example.com", "password", "유저"));
-			User target = userRepository.save(User.createLocalUser("invite3@example.com", "password", "초대"));
+			User owner = userRepository.save(User.createLocalUser("owner6@example.com", Password.ofEncoded("password"), "유저"));
+			User target = userRepository.save(User.createLocalUser("invite3@example.com", Password.ofEncoded("password"), "초대"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, target, WorkspaceMemberRole.MEMBER));
@@ -990,8 +996,8 @@ class WorkspaceServiceTest {
 		@DisplayName("탈퇴한 멤버는 다시 초대하면 복원된다")
 		void inviteWorkspaceMemberRestore() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner8@example.com", "password", "유저"));
-			User target = userRepository.save(User.createLocalUser("invite4@example.com", "password", "초대"));
+			User owner = userRepository.save(User.createLocalUser("owner8@example.com", Password.ofEncoded("password"), "유저"));
+			User target = userRepository.save(User.createLocalUser("invite4@example.com", Password.ofEncoded("password"), "초대"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 			WorkspaceMember member = workspaceMemberRepository.save(
@@ -1014,7 +1020,7 @@ class WorkspaceServiceTest {
 		@DisplayName("유저가 없으면 오류가 발생한다")
 		void inviteWorkspaceMemberUserNotFound() {
 			// given
-			User owner = userRepository.save(User.createLocalUser("owner7@example.com", "password", "유저"));
+			User owner = userRepository.save(User.createLocalUser("owner7@example.com", Password.ofEncoded("password"), "유저"));
 			Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 			workspaceMemberRepository.save(WorkspaceMember.create(workspace, owner, WorkspaceMemberRole.OWNER));
 

--- a/src/test/java/com/ujax/domain/auth/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/auth/RefreshTokenRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.ujax.domain.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.domain.user.Password;
+import com.ujax.domain.user.User;
+import com.ujax.domain.user.UserRepository;
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class RefreshTokenRepositoryTest {
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private User createAndSaveUser() {
+		User user = User.createLocalUser("test@example.com", Password.ofEncoded("password"), "테스트");
+		return userRepository.save(user);
+	}
+
+	@Test
+	@DisplayName("해시로 유효한 리프레시 토큰을 조회한다")
+	void findByTokenHashAndRevokedAtIsNull() {
+		// given
+		User user = createAndSaveUser();
+		String tokenHash = "validTokenHash";
+		RefreshToken refreshToken = RefreshToken.create(user, tokenHash, LocalDateTime.now().plusDays(30));
+		refreshTokenRepository.save(refreshToken);
+
+		// when
+		Optional<RefreshToken> found = refreshTokenRepository.findByTokenHashAndRevokedAtIsNull(tokenHash);
+
+		// then
+		assertThat(found).isPresent();
+		assertThat(found.get().getTokenHash()).isEqualTo(tokenHash);
+	}
+
+	@Test
+	@DisplayName("사용자의 모든 유효한 토큰을 해지한다")
+	void revokeAllByUserId() {
+		// given
+		User user = createAndSaveUser();
+		RefreshToken token1 = RefreshToken.create(user, "hash1", LocalDateTime.now().plusDays(30));
+		RefreshToken token2 = RefreshToken.create(user, "hash2", LocalDateTime.now().plusDays(30));
+		refreshTokenRepository.save(token1);
+		refreshTokenRepository.save(token2);
+
+		// when
+		refreshTokenRepository.revokeAllByUserId(user.getId(), LocalDateTime.now());
+
+		// then
+		assertThat(refreshTokenRepository.findByTokenHashAndRevokedAtIsNull("hash1")).isEmpty();
+		assertThat(refreshTokenRepository.findByTokenHashAndRevokedAtIsNull("hash2")).isEmpty();
+	}
+}

--- a/src/test/java/com/ujax/domain/auth/RefreshTokenTest.java
+++ b/src/test/java/com/ujax/domain/auth/RefreshTokenTest.java
@@ -1,0 +1,84 @@
+package com.ujax.domain.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.ujax.domain.user.AuthProvider;
+import com.ujax.domain.user.Password;
+import com.ujax.domain.user.User;
+
+class RefreshTokenTest {
+
+	private User createUser() {
+		return User.createLocalUser("test@example.com", Password.ofEncoded("password"), "테스트");
+	}
+
+	@Test
+	@DisplayName("리프레시 토큰을 생성한다")
+	void create() {
+		// given
+		User user = createUser();
+		String tokenHash = "hashedToken123";
+		LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+		// when
+		RefreshToken refreshToken = RefreshToken.create(user, tokenHash, expiresAt);
+
+		// then
+		assertThat(refreshToken).extracting("tokenHash", "revokedAt")
+			.containsExactly(tokenHash, null);
+		assertThat(refreshToken.getUser()).isEqualTo(user);
+		assertThat(refreshToken.isExpired()).isFalse();
+		assertThat(refreshToken.isRevoked()).isFalse();
+	}
+
+	@Nested
+	@DisplayName("토큰 만료 확인")
+	class IsExpired {
+
+		@Test
+		@DisplayName("만료된 토큰은 true를 반환한다")
+		void expired() {
+			// given
+			RefreshToken refreshToken = RefreshToken.create(
+				createUser(), "hash", LocalDateTime.now().minusDays(1)
+			);
+
+			// when & then
+			assertThat(refreshToken.isExpired()).isTrue();
+		}
+
+		@Test
+		@DisplayName("유효한 토큰은 false를 반환한다")
+		void notExpired() {
+			// given
+			RefreshToken refreshToken = RefreshToken.create(
+				createUser(), "hash", LocalDateTime.now().plusDays(30)
+			);
+
+			// when & then
+			assertThat(refreshToken.isExpired()).isFalse();
+		}
+	}
+
+	@Test
+	@DisplayName("토큰을 해지한다")
+	void revoke() {
+		// given
+		RefreshToken refreshToken = RefreshToken.create(
+			createUser(), "hash", LocalDateTime.now().plusDays(30)
+		);
+
+		// when
+		refreshToken.revoke();
+
+		// then
+		assertThat(refreshToken.isRevoked()).isTrue();
+		assertThat(refreshToken.getRevokedAt()).isNotNull();
+	}
+}

--- a/src/test/java/com/ujax/domain/user/PasswordTest.java
+++ b/src/test/java/com/ujax/domain/user/PasswordTest.java
@@ -1,0 +1,67 @@
+package com.ujax.domain.user;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.ujax.global.exception.common.BadRequestException;
+
+class PasswordTest {
+
+	private final PasswordEncoder encoder = new BCryptPasswordEncoder();
+
+	@Nested
+	@DisplayName("비밀번호 생성")
+	class Encode {
+
+		@Test
+		@DisplayName("유효한 비밀번호로 생성한다")
+		void encode_Success() {
+			// when
+			Password password = Password.encode("password1", encoder);
+
+			// then
+			assertThat(password.getEncodedValue()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("8자 미만이면 오류가 발생한다")
+		void encode_TooShort() {
+			// when & then
+			assertThatThrownBy(() -> Password.encode("pass1", encoder))
+				.isInstanceOf(BadRequestException.class);
+		}
+
+		@Test
+		@DisplayName("영문이 없으면 오류가 발생한다")
+		void encode_NoLetter() {
+			// when & then
+			assertThatThrownBy(() -> Password.encode("12345678", encoder))
+				.isInstanceOf(BadRequestException.class);
+		}
+
+		@Test
+		@DisplayName("숫자가 없으면 오류가 발생한다")
+		void encode_NoDigit() {
+			// when & then
+			assertThatThrownBy(() -> Password.encode("abcdefgh", encoder))
+				.isInstanceOf(BadRequestException.class);
+		}
+	}
+
+	@Test
+	@DisplayName("원본 비밀번호와 인코딩된 비밀번호가 일치한다")
+	void matches() {
+		// given
+		String raw = "password1";
+		Password password = Password.encode(raw, encoder);
+
+		// when & then
+		assertThat(password.matches(raw, encoder)).isTrue();
+		assertThat(password.matches("wrongpass1", encoder)).isFalse();
+	}
+}

--- a/src/test/java/com/ujax/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/user/UserRepositoryTest.java
@@ -98,14 +98,14 @@ class UserRepositoryTest {
 	@DisplayName("로컬 유저를 저장한다")
 	void save_LocalUser() {
 		// given
-		User user = User.createLocalUser("local@example.com", "password123!", "로컬유저");
+		User user = User.createLocalUser("local@example.com", Password.ofEncoded("password123!"), "로컬유저");
 
 		// when
 		User savedUser = userRepository.save(user);
 
 		// then
 		assertThat(savedUser.getId()).isNotNull();
-		assertThat(savedUser).extracting("provider", "password")
-			.containsExactly(AuthProvider.LOCAL, "password123!");
+		assertThat(savedUser.getProvider()).isEqualTo(AuthProvider.LOCAL);
+		assertThat(savedUser.getPassword().getEncodedValue()).isEqualTo("password123!");
 	}
 }

--- a/src/test/java/com/ujax/domain/user/UserTest.java
+++ b/src/test/java/com/ujax/domain/user/UserTest.java
@@ -57,11 +57,12 @@ class UserTest {
 			String name = "로컬유저";
 
 			// when
-			User user = User.createLocalUser(email, password, name);
+			User user = User.createLocalUser(email, Password.ofEncoded(password), name);
 
 			// then
-			assertThat(user).extracting("email", "password", "name", "provider", "providerId")
-				.containsExactly(email, password, name, AuthProvider.LOCAL, null);
+			assertThat(user).extracting("email", "name", "provider", "providerId")
+				.containsExactly(email, name, AuthProvider.LOCAL, null);
+			assertThat(user.getPassword().getEncodedValue()).isEqualTo(password);
 			assertThat(user.getProfileImageUrl()).isNotNull();
 		}
 	}

--- a/src/test/java/com/ujax/domain/workspace/WorkspaceMemberRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/workspace/WorkspaceMemberRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.ujax.domain.user.Password;
 import com.ujax.domain.user.User;
 import com.ujax.domain.user.UserRepository;
 import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
@@ -31,7 +32,7 @@ class WorkspaceMemberRepositoryTest {
 	@DisplayName("워크스페이스와 유저로 멤버를 조회할 수 있다")
 	void findByWorkspaceIdAndUserId() {
 		// given
-		User user = userRepository.save(User.createLocalUser("test@example.com", "password", "유저"));
+		User user = userRepository.save(User.createLocalUser("test@example.com", Password.ofEncoded("password"), "유저"));
 		Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 		workspaceMemberRepository.save(WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER));
 
@@ -49,7 +50,7 @@ class WorkspaceMemberRepositoryTest {
 	@DisplayName("워크스페이스 멤버 목록을 조회할 수 있다")
 	void findByWorkspaceId() {
 		// given
-		User user = userRepository.save(User.createLocalUser("list@example.com", "password", "유저"));
+		User user = userRepository.save(User.createLocalUser("list@example.com", Password.ofEncoded("password"), "유저"));
 		Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 		workspaceMemberRepository.save(WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER));
 

--- a/src/test/java/com/ujax/domain/workspace/WorkspaceMemberTest.java
+++ b/src/test/java/com/ujax/domain/workspace/WorkspaceMemberTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.ujax.domain.user.Password;
 import com.ujax.domain.user.User;
 
 class WorkspaceMemberTest {
@@ -19,7 +20,7 @@ class WorkspaceMemberTest {
 		void updateRole() {
 			// given
 			Workspace workspace = Workspace.create("워크스페이스", "소개");
-			User user = User.createLocalUser("test@example.com", "password", "유저");
+			User user = User.createLocalUser("test@example.com", Password.ofEncoded("password"), "유저");
 			WorkspaceMember member = WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER);
 
 			// when

--- a/src/test/java/com/ujax/domain/workspace/WorkspaceRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/workspace/WorkspaceRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.ujax.domain.user.Password;
 import com.ujax.domain.user.User;
 import com.ujax.domain.user.UserRepository;
 import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
@@ -49,7 +50,7 @@ class WorkspaceRepositoryTest {
 	@DisplayName("유저가 속한 워크스페이스를 조회할 수 있다")
 	void findByMemberUserId() {
 		// given
-		User user = userRepository.save(User.createLocalUser("test@example.com", "password", "유저"));
+		User user = userRepository.save(User.createLocalUser("test@example.com", Password.ofEncoded("password"), "유저"));
 		Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
 		workspaceMemberRepository.save(WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER));
 

--- a/src/test/java/com/ujax/infrastructure/web/api/auth/AuthControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/auth/AuthControllerDocsTest.java
@@ -1,0 +1,210 @@
+package com.ujax.infrastructure.web.api.auth;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ujax.application.auth.AuthService;
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.infrastructure.web.auth.AuthController;
+import com.ujax.infrastructure.web.auth.dto.request.LoginRequest;
+import com.ujax.infrastructure.web.auth.dto.request.RefreshRequest;
+import com.ujax.infrastructure.web.auth.dto.request.SignupRequest;
+import com.ujax.support.TestSecurityConfig;
+
+@Tag("restDocs")
+@WebMvcTest(AuthController.class)
+@AutoConfigureRestDocs
+@Import(TestSecurityConfig.class)
+class AuthControllerDocsTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private AuthService authService;
+
+	@Test
+	@DisplayName("회원가입 API")
+	void signup() throws Exception {
+		// given
+		SignupRequest request = new SignupRequest("test@example.com", "password123", "테스트유저");
+		AuthTokenResponse response = new AuthTokenResponse("access.token.here", "refresh.token.here");
+		given(authService.signup(anyString(), anyString(), anyString())).willReturn(response);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/signup")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.accessToken").exists())
+			.andExpect(jsonPath("$.data.refreshToken").exists())
+			.andDo(document("auth-signup",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Auth")
+					.summary("회원가입")
+					.description("이메일/비밀번호로 회원가입합니다")
+					.requestSchema(Schema.schema("SignupRequest"))
+					.responseSchema(Schema.schema("ApiResponse-AuthTokenResponse"))
+					.requestFields(
+						fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+						fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+						fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
+						fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("로그인 API")
+	void login() throws Exception {
+		// given
+		LoginRequest request = new LoginRequest("test@example.com", "password123");
+		AuthTokenResponse response = new AuthTokenResponse("access.token.here", "refresh.token.here");
+		given(authService.login(anyString(), anyString())).willReturn(response);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.accessToken").exists())
+			.andDo(document("auth-login",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Auth")
+					.summary("로그인")
+					.description("이메일/비밀번호로 로그인합니다")
+					.requestSchema(Schema.schema("LoginRequest"))
+					.responseSchema(Schema.schema("ApiResponse-AuthTokenResponse"))
+					.requestFields(
+						fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+						fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
+						fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 갱신 API")
+	void refresh() throws Exception {
+		// given
+		RefreshRequest request = new RefreshRequest("refresh.token.here");
+		AuthTokenResponse response = new AuthTokenResponse("new.access.token", "new.refresh.token");
+		given(authService.refresh(anyString())).willReturn(response);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/refresh")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andDo(document("auth-refresh",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Auth")
+					.summary("토큰 갱신")
+					.description("리프레시 토큰으로 새 토큰을 발급받습니다")
+					.requestSchema(Schema.schema("RefreshRequest"))
+					.responseSchema(Schema.schema("ApiResponse-AuthTokenResponse"))
+					.requestFields(
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+						fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("새 액세스 토큰"),
+						fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("새 리프레시 토큰"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("로그아웃 API")
+	void logout() throws Exception {
+		// given
+		RefreshRequest request = new RefreshRequest("refresh.token.here");
+		willDoNothing().given(authService).logout(anyString());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/logout")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andDo(document("auth-logout",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Auth")
+					.summary("로그아웃")
+					.description("리프레시 토큰을 해지합니다")
+					.requestSchema(Schema.schema("RefreshRequest"))
+					.responseSchema(Schema.schema("ApiResponse-Void"))
+					.requestFields(
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+						fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터").optional(),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
+					)
+					.build()
+				)
+			));
+	}
+}

--- a/src/test/java/com/ujax/infrastructure/web/api/auth/AuthControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/auth/AuthControllerTest.java
@@ -1,0 +1,148 @@
+package com.ujax.infrastructure.web.api.auth;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ujax.application.auth.AuthService;
+import com.ujax.application.auth.dto.response.AuthTokenResponse;
+import com.ujax.infrastructure.web.auth.AuthController;
+import com.ujax.infrastructure.web.auth.dto.request.LoginRequest;
+import com.ujax.infrastructure.web.auth.dto.request.RefreshRequest;
+import com.ujax.infrastructure.web.auth.dto.request.SignupRequest;
+import com.ujax.support.TestSecurityConfig;
+
+@WebMvcTest(AuthController.class)
+@Import(TestSecurityConfig.class)
+class AuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private AuthService authService;
+
+	@Nested
+	@DisplayName("회원가입")
+	class Signup {
+
+		@Test
+		@DisplayName("이메일이 비어있으면 오류가 발생한다")
+		void signup_BlankEmail() throws Exception {
+			// given
+			SignupRequest request = new SignupRequest("", "password123", "이름");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/signup")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("비밀번호가 비어있으면 오류가 발생한다")
+		void signup_BlankPassword() throws Exception {
+			// given
+			SignupRequest request = new SignupRequest("test@example.com", "", "이름");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/signup")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("이메일 형식이 올바르지 않으면 오류가 발생한다")
+		void signup_InvalidEmail() throws Exception {
+			// given
+			SignupRequest request = new SignupRequest("invalid-email", "password123", "이름");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/signup")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("이름이 비어있으면 오류가 발생한다")
+		void signup_BlankName() throws Exception {
+			// given
+			SignupRequest request = new SignupRequest("test@example.com", "password123", "");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/signup")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("로그인")
+	class Login {
+
+		@Test
+		@DisplayName("이메일이 비어있으면 오류가 발생한다")
+		void login_BlankEmail() throws Exception {
+			// given
+			LoginRequest request = new LoginRequest("", "password123");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("비밀번호가 비어있으면 오류가 발생한다")
+		void login_BlankPassword() throws Exception {
+			// given
+			LoginRequest request = new LoginRequest("test@example.com", "");
+
+			// when & then
+			mockMvc.perform(post("/api/v1/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Test
+	@DisplayName("리프레시 토큰이 비어있으면 오류가 발생한다")
+	void refresh_BlankToken() throws Exception {
+		// given
+		RefreshRequest request = new RefreshRequest("");
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/refresh")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
+}

--- a/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerDocsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -33,10 +34,12 @@ import com.ujax.application.problem.dto.response.ProblemResponse;
 import com.ujax.application.problem.dto.response.SampleResponse;
 import com.ujax.infrastructure.web.problem.ProblemController;
 import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+import com.ujax.support.TestSecurityConfig;
 
 @Tag("restDocs")
 @WebMvcTest(ProblemController.class)
 @AutoConfigureRestDocs
+@Import(TestSecurityConfig.class)
 class ProblemControllerDocsTest {
 
 	@Autowired

--- a/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/problem/ProblemControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,8 +25,10 @@ import com.ujax.application.problem.dto.response.ProblemResponse;
 import com.ujax.application.problem.dto.response.SampleResponse;
 import com.ujax.infrastructure.web.problem.ProblemController;
 import com.ujax.infrastructure.web.problem.dto.request.ProblemIngestRequest;
+import com.ujax.support.TestSecurityConfig;
 
 @WebMvcTest(ProblemController.class)
+@Import(TestSecurityConfig.class)
 class ProblemControllerTest {
 
 	@Autowired

--- a/src/test/java/com/ujax/infrastructure/web/api/user/UserControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/user/UserControllerDocsTest.java
@@ -13,14 +13,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -28,11 +32,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ujax.application.user.UserService;
 import com.ujax.application.user.dto.response.UserResponse;
 import com.ujax.domain.user.AuthProvider;
+import com.ujax.infrastructure.security.UserPrincipal;
 import com.ujax.infrastructure.web.user.UserController;
 import com.ujax.infrastructure.web.user.dto.request.UserUpdateRequest;
+import com.ujax.support.TestSecurityConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
 @Tag("restDocs")
 @WebMvcTest(UserController.class)
 @AutoConfigureRestDocs
+@Import(TestSecurityConfig.class)
 class UserControllerDocsTest {
 
 	@Autowired
@@ -43,6 +54,20 @@ class UserControllerDocsTest {
 
 	@MockitoBean
 	private UserService userService;
+
+	@BeforeEach
+	void setUpSecurityContext() {
+		Claims claims = Jwts.claims()
+			.subject("1")
+			.add("role", "USER")
+			.add("name", "테스트유저")
+			.add("email", "test@example.com")
+			.build();
+		UserPrincipal principal = UserPrincipal.fromClaims(claims);
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+		);
+	}
 
 	@Test
 	@DisplayName("내 정보 조회 API")

--- a/src/test/java/com/ujax/infrastructure/web/api/user/UserControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/user/UserControllerTest.java
@@ -6,12 +6,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,10 +23,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ujax.application.user.UserService;
 import com.ujax.application.user.dto.response.UserResponse;
 import com.ujax.domain.user.AuthProvider;
+import com.ujax.infrastructure.security.UserPrincipal;
 import com.ujax.infrastructure.web.user.UserController;
 import com.ujax.infrastructure.web.user.dto.request.UserUpdateRequest;
+import com.ujax.support.TestSecurityConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 @WebMvcTest(UserController.class)
+@Import(TestSecurityConfig.class)
 class UserControllerTest {
 
 	@Autowired
@@ -33,6 +43,20 @@ class UserControllerTest {
 
 	@MockitoBean
 	private UserService userService;
+
+	@BeforeEach
+	void setUpSecurityContext() {
+		Claims claims = Jwts.claims()
+			.subject("1")
+			.add("role", "USER")
+			.add("name", "테스트유저")
+			.add("email", "test@example.com")
+			.build();
+		UserPrincipal principal = UserPrincipal.fromClaims(claims);
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+		);
+	}
 
 	@Nested
 	@DisplayName("내 정보 수정")

--- a/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerDocsTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,19 +42,24 @@ import com.ujax.domain.workspace.WorkspaceMemberRole;
 import com.ujax.global.dto.PageResponse;
 import com.ujax.global.exception.ErrorCode;
 import com.ujax.global.exception.GlobalExceptionHandler;
-import com.ujax.global.exception.common.NotFoundException;
 import com.ujax.global.exception.common.ForbiddenException;
+import com.ujax.global.exception.common.NotFoundException;
+import com.ujax.infrastructure.security.UserPrincipal;
 import com.ujax.infrastructure.web.workspace.WorkspaceController;
 import com.ujax.infrastructure.web.workspace.dto.request.CreateWorkspaceRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.InviteWorkspaceMemberRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.UpdateWorkspaceMemberNicknameRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.UpdateWorkspaceMemberRoleRequest;
 import com.ujax.infrastructure.web.workspace.dto.request.UpdateWorkspaceRequest;
+import com.ujax.support.TestSecurityConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 @Tag("restDocs")
 @WebMvcTest(WorkspaceController.class)
 @AutoConfigureRestDocs
-@Import(GlobalExceptionHandler.class)
+@Import({TestSecurityConfig.class, GlobalExceptionHandler.class})
 class WorkspaceControllerDocsTest {
 
 	@Autowired
@@ -62,6 +70,20 @@ class WorkspaceControllerDocsTest {
 
 	@MockitoBean
 	private WorkspaceService workspaceService;
+
+	@BeforeEach
+	void setUpSecurityContext() {
+		Claims claims = Jwts.claims()
+			.subject("1")
+			.add("role", "USER")
+			.add("name", "테스트유저")
+			.add("email", "test@example.com")
+			.build();
+		UserPrincipal principal = UserPrincipal.fromClaims(claims);
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+		);
+	}
 
 	@Test
 	@DisplayName("워크스페이스 탐색 목록 조회 API")
@@ -220,7 +242,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces")
-				.param("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -231,9 +252,6 @@ class WorkspaceControllerDocsTest {
 					.tag("Workspace")
 					.summary("내 워크스페이스 목록 조회")
 					.description("유저가 속한 워크스페이스 목록을 조회합니다")
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
-					)
 					.responseSchema(Schema.schema("ApiResponse-WorkspaceList"))
 					.responseFields(
 						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -244,28 +262,6 @@ class WorkspaceControllerDocsTest {
 						fieldWithPath("data.items[].description").type(JsonFieldType.STRING).description("워크스페이스 설명").optional(),
 						fieldWithPath("message").type(JsonFieldType.STRING).description("메시지").optional()
 					)
-					.build()
-				)
-			));
-	}
-
-	@Test
-	@DisplayName("내 워크스페이스 목록 조회 API - userId 누락")
-	void listMyWorkspacesMissingUserId() throws Exception {
-		// when & then
-		mockMvc.perform(get("/api/v1/workspaces")
-				.contentType(MediaType.APPLICATION_JSON))
-			.andDo(print())
-			.andExpect(status().isBadRequest())
-			.andDo(document("workspace-my-list-error",
-				preprocessRequest(prettyPrint()),
-				preprocessResponse(prettyPrint()),
-				resource(ResourceSnippetParameters.builder()
-					.tag("Workspace")
-					.summary("내 워크스페이스 목록 조회")
-					.description("내 워크스페이스 목록 조회")
-					.responseSchema(Schema.schema("ProblemDetail-MissingParameter"))
-					.responseFields(problemDetailFields())
 					.build()
 				)
 			));
@@ -345,7 +341,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/settings", 1)
-				.param("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -358,9 +353,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 설정 정보를 조회합니다 (소유자 전용)")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-WorkspaceSettings"))
 					.responseFields(
@@ -386,7 +378,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/settings", 1)
-				.queryParam("userId", "2")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -399,9 +390,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 설정 조회")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -420,7 +408,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/members", 1)
-				.param("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -433,9 +420,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스에 속한 멤버 목록을 조회합니다")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-WorkspaceMemberList"))
 					.responseFields(
@@ -461,7 +445,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/members", 1)
-				.queryParam("userId", "2")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -474,9 +457,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 멤버 목록 조회")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -494,7 +474,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/members/me", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -507,9 +486,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스에서 자신의 멤버 정보를 조회합니다")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-WorkspaceMemberResponse"))
 					.responseFields(
@@ -534,7 +510,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceId}/members/me", 1)
-				.queryParam("userId", "2")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -547,9 +522,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 멤버 조회")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -568,7 +540,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}/members/me/nickname", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -582,9 +553,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 닉네임 수정")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("UpdateWorkspaceMemberNicknameRequest"))
 					.requestFields(
@@ -612,7 +580,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}/members/me/nickname", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -626,9 +593,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 닉네임 수정")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("UpdateWorkspaceMemberNicknameRequest"))
 					.requestFields(
@@ -645,7 +609,7 @@ class WorkspaceControllerDocsTest {
 	@DisplayName("워크스페이스 생성 API")
 	void createWorkspace() throws Exception {
 		// given
-		CreateWorkspaceRequest request = new CreateWorkspaceRequest("워크스페이스", "소개", 1L);
+		CreateWorkspaceRequest request = new CreateWorkspaceRequest("워크스페이스", "소개");
 		WorkspaceResponse response = new WorkspaceResponse(1L, "워크스페이스", "소개");
 		given(workspaceService.createWorkspace(anyString(), any(), anyLong())).willReturn(response);
 
@@ -665,8 +629,7 @@ class WorkspaceControllerDocsTest {
 					.requestSchema(Schema.schema("CreateWorkspaceRequest"))
 					.requestFields(
 						fieldWithPath("name").type(JsonFieldType.STRING).description("워크스페이스 이름"),
-						fieldWithPath("description").type(JsonFieldType.STRING).description("워크스페이스 설명").optional(),
-						fieldWithPath("userId").type(JsonFieldType.NUMBER).description("소유자 유저 ID")
+						fieldWithPath("description").type(JsonFieldType.STRING).description("워크스페이스 설명").optional()
 					)
 					.responseSchema(Schema.schema("ApiResponse-WorkspaceResponse"))
 					.responseFields(
@@ -686,7 +649,7 @@ class WorkspaceControllerDocsTest {
 	@DisplayName("워크스페이스 생성 API - 유효성 오류")
 	void createWorkspaceValidationError() throws Exception {
 		// given
-		CreateWorkspaceRequest request = new CreateWorkspaceRequest("", "소개", 1L);
+		CreateWorkspaceRequest request = new CreateWorkspaceRequest("", "소개");
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces")
@@ -704,8 +667,7 @@ class WorkspaceControllerDocsTest {
 					.requestSchema(Schema.schema("CreateWorkspaceRequest"))
 					.requestFields(
 						fieldWithPath("name").type(JsonFieldType.STRING).description("워크스페이스 이름"),
-						fieldWithPath("description").type(JsonFieldType.STRING).description("워크스페이스 설명").optional(),
-						fieldWithPath("userId").type(JsonFieldType.NUMBER).description("소유자 유저 ID")
+						fieldWithPath("description").type(JsonFieldType.STRING).description("워크스페이스 설명").optional()
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Validation"))
 					.responseFields(problemDetailFieldsWithFieldErrors())
@@ -724,7 +686,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -738,9 +699,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 정보를 수정합니다")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("UpdateWorkspaceRequest"))
 					.requestFields(
@@ -773,7 +731,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -787,9 +744,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 수정")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("UpdateWorkspaceRequest"))
 					.requestFields(
@@ -812,7 +766,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -825,9 +778,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스를 삭제합니다")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-Void"))
 					.responseFields(
@@ -849,7 +799,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}", 1)
-				.queryParam("userId", "2")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -862,9 +811,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 삭제")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -882,7 +828,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}/role", 1, 2)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -897,9 +842,6 @@ class WorkspaceControllerDocsTest {
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID"),
 						parameterWithName("workspaceMemberId").description("워크스페이스 멤버 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("UpdateWorkspaceMemberRoleRequest"))
 					.requestFields(
@@ -921,7 +863,6 @@ class WorkspaceControllerDocsTest {
 	void updateWorkspaceMemberRoleValidationError() throws Exception {
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}/role", 1, 2)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andDo(print())
@@ -936,9 +877,6 @@ class WorkspaceControllerDocsTest {
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID"),
 						parameterWithName("workspaceMemberId").description("워크스페이스 멤버 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Validation"))
 					.responseFields(problemDetailFieldsWithFieldErrors())
@@ -955,7 +893,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}", 1, 2)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -969,9 +906,6 @@ class WorkspaceControllerDocsTest {
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID"),
 						parameterWithName("workspaceMemberId").description("워크스페이스 멤버 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-Void"))
 					.responseFields(
@@ -993,7 +927,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}/members/{workspaceMemberId}", 1, 2)
-				.queryParam("userId", "2")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -1007,9 +940,6 @@ class WorkspaceControllerDocsTest {
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID"),
 						parameterWithName("workspaceMemberId").description("워크스페이스 멤버 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -1026,7 +956,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}/members/me", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -1039,9 +968,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스에서 탈퇴합니다")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ApiResponse-Void"))
 					.responseFields(
@@ -1063,7 +989,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{workspaceId}/members/me", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isForbidden())
@@ -1076,9 +1001,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 탈퇴")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.responseSchema(Schema.schema("ProblemDetail-Forbidden"))
 					.responseFields(problemDetailFields())
@@ -1096,7 +1018,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces/{workspaceId}/members/invite", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -1108,8 +1029,8 @@ class WorkspaceControllerDocsTest {
 					.tag("Workspace")
 					.summary("워크스페이스 멤버 초대")
 					.description("워크스페이스 소유자가 이메일로 멤버를 초대합니다")
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
+					.pathParameters(
+						parameterWithName("workspaceId").description("워크스페이스 ID")
 					)
 					.requestSchema(Schema.schema("InviteWorkspaceMemberRequest"))
 					.requestFields(
@@ -1134,7 +1055,6 @@ class WorkspaceControllerDocsTest {
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces/{workspaceId}/members/invite", 1)
-				.queryParam("userId", "1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print())
@@ -1148,9 +1068,6 @@ class WorkspaceControllerDocsTest {
 					.description("워크스페이스 멤버 초대")
 					.pathParameters(
 						parameterWithName("workspaceId").description("워크스페이스 ID")
-					)
-					.queryParameters(
-						parameterWithName("userId").description("요청자 유저 ID")
 					)
 					.requestSchema(Schema.schema("InviteWorkspaceMemberRequest"))
 					.requestFields(

--- a/src/test/java/com/ujax/support/TestSecurityConfig.java
+++ b/src/test/java/com/ujax/support/TestSecurityConfig.java
@@ -1,0 +1,63 @@
+package com.ujax.support;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.ujax.infrastructure.security.jwt.JwtAuthenticationFilter;
+import com.ujax.infrastructure.security.jwt.JwtProperties;
+import com.ujax.infrastructure.security.jwt.JwtTokenProvider;
+import com.ujax.infrastructure.security.oauth2.CustomOAuth2UserService;
+import com.ujax.infrastructure.security.oauth2.OAuth2LoginFailureHandler;
+import com.ujax.infrastructure.security.oauth2.OAuth2LoginSuccessHandler;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+	@Bean
+	@Order(0)
+	public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+		return http.build();
+	}
+
+	@Bean
+	public JwtProperties jwtProperties() {
+		return new JwtProperties(
+			"testSecretKeyThatIsAtLeast256BitsLongForHmacSha256AlgorithmInTestProfile",
+			1800000L,
+			2592000000L
+		);
+	}
+
+	@Bean
+	public JwtTokenProvider jwtTokenProvider() {
+		return new JwtTokenProvider(jwtProperties());
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwtTokenProvider());
+	}
+
+	@Bean
+	public CustomOAuth2UserService customOAuth2UserService() {
+		return Mockito.mock(CustomOAuth2UserService.class);
+	}
+
+	@Bean
+	public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
+		return Mockito.mock(OAuth2LoginSuccessHandler.class);
+	}
+
+	@Bean
+	public OAuth2LoginFailureHandler oAuth2LoginFailureHandler() {
+		return Mockito.mock(OAuth2LoginFailureHandler.class);
+	}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,3 +23,9 @@ spring:
       mode: never
   flyway:
     enabled: false
+
+app:
+  jwt:
+    secret: testSecretKeyThatIsAtLeast256BitsLongForHmacSha256AlgorithmInTestProfile
+    access-expiration: 1800000
+    refresh-expiration: 2592000000


### PR DESCRIPTION
# 관련 작업 / 이슈

>   JWT + Spring Security + OAuth2 인증/인가 구현    

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

  - JWT 기반 인증 체계 구축 (Access Token 30분 / Refresh Token 30일)
  - OAuth2 소셜 로그인 지원 (Google, Kakao)
  - 이메일/비밀번호 자체 로그인 (회원가입, 로그인, 토큰 갱신, 로그아웃)
  - 기존 Controller의 하드코딩 userId = 1L 및 @RequestParam Long userId → @AuthenticationPrincipal
  UserPrincipal 교체
  - CreateWorkspaceRequest에서 userId 필드 제거
  - Password Value Object(@Embeddable) 도입 및 비밀번호 정책 적용 (8자 이상, 영문+숫자 필수)
  - Swagger UI에 Bearer JWT 인증 지원 추가

 ### 토큰 상세
  - Access Token: HMAC-SHA256 서명, Claims에 userId, role, name, email 포함
  - Refresh Token: SecureRandom 48byte → Base64 → SHA-256 해시를 refresh_tokens 테이블에 저장
  - Refresh 시 기존 토큰 revoke 후 새 토큰 발급 (Rotation)

  기존 Controller 변경

  - UserController: userId = 1L 하드코딩 → @AuthenticationPrincipal (3개 메서드)
  - WorkspaceController: @RequestParam Long userId → @AuthenticationPrincipal (12개 메서드)
  - CreateWorkspaceRequest: @NotNull Long userId 필드 삭제



---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명:
<img width="639" height="166" alt="image" src="https://github.com/user-attachments/assets/9bbbdbdf-4403-48cf-a2e3-4ea44ca8eeec" />
<img width="636" height="341" alt="image" src="https://github.com/user-attachments/assets/ed715a35-937c-4997-ba2e-f35968c58e12" />
<img width="637" height="244" alt="image" src="https://github.com/user-attachments/assets/f536317b-9204-4559-9aba-82d60ba21dc4" />

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [ ] Yes (호환성 깨짐 있음)
- [x] No

  - 모든 인증 필요 API에 Authorization: Bearer {token} 헤더 필수
  - WorkspaceController: @RequestParam userId 제거됨 → 프론트엔드에서 userId 파라미터 전송 불필요
  - CreateWorkspaceRequest: userId 필드 삭제 → 요청 바디에서 userId 제거 필요
  - DB: refresh_tokens 테이블 추가, users 테이블에 role, password 컬럼 추가 필요 (Flyway 마이그레이션 작성
  필요)

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.
<img width="870" height="313" alt="image" src="https://github.com/user-attachments/assets/caf9a691-72c8-42d2-bfef-db1393f284cd" />

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO:
- 추후 리팩터링/성능 개선 포인트: 후에 테스트 커버리지 수준을 올릴 예정
- 다른 모듈/서비스와의 의존성 또는 영향:

