### PR TITLE
fix: API 명세 갱신 및 중복 어노테이션 제거

### DIFF
--- a/src/main/resources/static/swagger/openapi3.yaml
+++ b/src/main/resources/static/swagger/openapi3.yaml
@@ -10,33 +10,6 @@ security:
 tags: []
 paths:
   /api/v1/workspaces:
-    get:
-      tags:
-      - Workspace
-      summary: 내 워크스페이스 목록 조회
-      description: 유저가 속한 워크스페이스 목록을 조회합니다
-      operationId: workspace-my-list
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiResponse-WorkspaceList"
-              examples:
-                workspace-my-list:
-                  value: |-
-                    {
-                      "success" : true,
-                      "data" : {
-                        "items" : [ {
-                          "id" : 1,
-                          "name" : "워크스페이스",
-                          "description" : "소개"
-                        } ]
-                      },
-                      "message" : null
-                    }
     post:
       tags:
       - Workspace
@@ -78,7 +51,7 @@ paths:
                       "detail" : "잘못된 요청 형식입니다.",
                       "instance" : "/api/v1/workspaces",
                       "exception" : "MethodArgumentNotValidException",
-                      "timestamp" : "2026-02-24T19:44:29.301638",
+                      "timestamp" : "2026-02-25T12:58:59.97093",
                       "fieldErrors" : [ {
                         "field" : "name",
                         "rejectedValue" : "",
@@ -488,6 +461,12 @@ paths:
       description: 워크스페이스 탐색 페이지에서 목록을 조회합니다
       operationId: workspace-explore
       parameters:
+      - name: name
+        in: query
+        description: 검색어
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: 페이지 번호
@@ -545,22 +524,16 @@ paths:
                       "detail" : "파라미터 'page'의 타입이 올바르지 않습니다. (기대 타입: int)",
                       "instance" : "/api/v1/workspaces/explore",
                       "exception" : "MethodArgumentTypeMismatchException",
-                      "timestamp" : "2026-02-24T19:44:29.245888"
+                      "timestamp" : "2026-02-25T12:58:59.922524"
                     }
-  /api/v1/workspaces/search:
+  /api/v1/workspaces/me:
     get:
       tags:
       - Workspace
-      summary: 워크스페이스 검색
-      description: 워크스페이스 검색
-      operationId: workspace-search
+      summary: 내 워크스페이스 목록 조회
+      description: 유저가 속한 워크스페이스 목록을 조회합니다 (/me)
+      operationId: workspace-my-list-me
       parameters:
-      - name: name
-        in: query
-        description: 검색어
-        required: true
-        schema:
-          type: string
       - name: page
         in: query
         description: 페이지 번호
@@ -574,32 +547,14 @@ paths:
         schema:
           type: string
       responses:
-        "400":
-          description: "400"
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail-MissingParameter"
-              examples:
-                workspace-search-error:
-                  value: |-
-                    {
-                      "type" : "/docs/index.html#error-code-list",
-                      "title" : "C003",
-                      "status" : 400,
-                      "detail" : "필수 파라미터 'name'이(가) 누락되었습니다.",
-                      "instance" : "/api/v1/workspaces/search",
-                      "exception" : "MissingServletRequestParameterException",
-                      "timestamp" : "2026-02-24T19:44:29.399122"
-                    }
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApiResponse-WorkspaceSearch"
+                $ref: "#/components/schemas/ApiResponse-WorkspaceMyPage"
               examples:
-                workspace-search:
+                workspace-my-list-me:
                   value: |-
                     {
                       "success" : true,
@@ -651,7 +606,7 @@ paths:
                       "detail" : "워크스페이스를 찾을 수 없습니다.",
                       "instance" : "/api/v1/workspaces/999",
                       "exception" : "NotFoundException",
-                      "timestamp" : "2026-02-24T19:44:29.43905"
+                      "timestamp" : "2026-02-25T12:59:00.178822"
                     }
         "200":
           description: "200"
@@ -715,7 +670,7 @@ paths:
                       "detail" : "소유자만 이 작업을 수행할 수 있습니다.",
                       "instance" : "/api/v1/workspaces/1",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.314795"
+                      "timestamp" : "2026-02-25T12:58:59.985065"
                     }
     patch:
       tags:
@@ -785,7 +740,7 @@ paths:
                       "detail" : "잘못된 요청 형식입니다.",
                       "instance" : "/api/v1/workspaces/1",
                       "exception" : "BadRequestException",
-                      "timestamp" : "2026-02-24T19:44:29.209247"
+                      "timestamp" : "2026-02-25T12:58:59.878624"
                     }
   /api/v1/problems/number/{problemNumber}:
     get:
@@ -923,8 +878,8 @@ paths:
                             "workspaceMemberId" : 3,
                             "nickname" : "작성자"
                           },
-                          "createdAt" : "2026-02-24T19:44:28.417114",
-                          "updatedAt" : "2026-02-24T19:44:28.417127"
+                          "createdAt" : "2026-02-25T12:58:59.020303",
+                          "updatedAt" : "2026-02-25T12:58:59.020316"
                         } ],
                         "page" : {
                           "page" : 0,
@@ -991,8 +946,8 @@ paths:
                           "workspaceMemberId" : 3,
                           "nickname" : "작성자"
                         },
-                        "createdAt" : "2026-02-24T19:44:28.360446",
-                        "updatedAt" : "2026-02-24T19:44:28.360465"
+                        "createdAt" : "2026-02-25T12:58:58.944528",
+                        "updatedAt" : "2026-02-25T12:58:58.94454"
                       },
                       "message" : null
                     }
@@ -1027,7 +982,7 @@ paths:
                       "detail" : "워크스페이스에 소속된 멤버가 아닙니다.",
                       "instance" : "/api/v1/workspaces/1/members",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.25745"
+                      "timestamp" : "2026-02-25T12:58:59.93463"
                     }
         "200":
           description: "200"
@@ -1080,7 +1035,7 @@ paths:
                       "detail" : "소유자만 이 작업을 수행할 수 있습니다.",
                       "instance" : "/api/v1/workspaces/1/settings",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.458444"
+                      "timestamp" : "2026-02-25T12:59:00.204646"
                     }
         "200":
           description: "200"
@@ -1186,8 +1141,8 @@ paths:
                           "workspaceMemberId" : 3,
                           "nickname" : "작성자"
                         },
-                        "createdAt" : "2026-02-24T19:44:28.498955",
-                        "updatedAt" : "2026-02-24T19:44:28.498966"
+                        "createdAt" : "2026-02-25T12:58:59.116382",
+                        "updatedAt" : "2026-02-25T12:58:59.116394"
                       },
                       "message" : null
                     }
@@ -1285,8 +1240,8 @@ paths:
                           "workspaceMemberId" : 3,
                           "nickname" : "작성자"
                         },
-                        "createdAt" : "2026-02-24T19:44:28.322788",
-                        "updatedAt" : "2026-02-24T19:44:28.322799"
+                        "createdAt" : "2026-02-25T12:58:58.898631",
+                        "updatedAt" : "2026-02-25T12:58:58.898643"
                       },
                       "message" : null
                     }
@@ -1337,7 +1292,7 @@ paths:
                       "detail" : "잘못된 요청 형식입니다.",
                       "instance" : "/api/v1/workspaces/1/members/invite",
                       "exception" : "MethodArgumentNotValidException",
-                      "timestamp" : "2026-02-24T19:44:29.327098",
+                      "timestamp" : "2026-02-25T12:58:59.999493",
                       "fieldErrors" : [ {
                         "field" : "email",
                         "rejectedValue" : "invalid-email",
@@ -1389,7 +1344,7 @@ paths:
                       "detail" : "워크스페이스에 소속된 멤버가 아닙니다.",
                       "instance" : "/api/v1/workspaces/1/members/me",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.425552"
+                      "timestamp" : "2026-02-25T12:59:00.160535"
                     }
         "200":
           description: "200"
@@ -1439,7 +1394,7 @@ paths:
                       "detail" : "워크스페이스에 대한 권한이 없습니다.",
                       "instance" : "/api/v1/workspaces/1/members/me",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.449475"
+                      "timestamp" : "2026-02-25T12:59:00.190122"
                     }
         "200":
           description: "200"
@@ -1492,7 +1447,7 @@ paths:
                       "detail" : "워크스페이스에 대한 권한이 없습니다.",
                       "instance" : "/api/v1/workspaces/1/members/2",
                       "exception" : "ForbiddenException",
-                      "timestamp" : "2026-02-24T19:44:29.234985"
+                      "timestamp" : "2026-02-25T12:58:59.909759"
                     }
         "200":
           description: "200"
@@ -1561,7 +1516,7 @@ paths:
                             "workspaceMemberId" : 3,
                             "nickname" : "작성자"
                           },
-                          "createdAt" : "2026-02-24T19:44:28.469156"
+                          "createdAt" : "2026-02-25T12:58:59.08046"
                         } ],
                         "page" : {
                           "page" : 0,
@@ -1624,7 +1579,7 @@ paths:
                           "workspaceMemberId" : 3,
                           "nickname" : "작성자"
                         },
-                        "createdAt" : "2026-02-24T19:44:28.285724"
+                        "createdAt" : "2026-02-25T12:58:58.855632"
                       },
                       "message" : null
                     }
@@ -1827,7 +1782,7 @@ paths:
                       "detail" : "잘못된 요청 형식입니다.",
                       "instance" : "/api/v1/workspaces/1/members/me/nickname",
                       "exception" : "MethodArgumentNotValidException",
-                      "timestamp" : "2026-02-24T19:44:29.39118",
+                      "timestamp" : "2026-02-25T12:59:00.100393",
                       "fieldErrors" : [ {
                         "field" : "nickname",
                         "rejectedValue" : "",
@@ -1916,7 +1871,7 @@ paths:
                       "detail" : "잘못된 요청 형식입니다.",
                       "instance" : "/api/v1/workspaces/1/members/2/role",
                       "exception" : "MethodArgumentNotValidException",
-                      "timestamp" : "2026-02-24T19:44:29.355699",
+                      "timestamp" : "2026-02-25T12:59:00.047014",
                       "fieldErrors" : [ {
                         "field" : "role",
                         "rejectedValue" : null,
@@ -2134,23 +2089,6 @@ components:
           type: string
           description: 메시지
           nullable: true
-    ApiResponse-BoardList:
-      title: ApiResponse-BoardList
-      required:
-      - data
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          description: 응답 데이터
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 메시지
-          nullable: true
     ApiResponse-UserResponse:
       title: ApiResponse-UserResponse
       required:
@@ -2214,37 +2152,15 @@ components:
           type: string
           description: 내용
           nullable: true
-    ApiResponse-WorkspaceList:
-      title: ApiResponse-WorkspaceList
+    ApiResponse-BoardList:
+      title: ApiResponse-BoardList
       required:
       - data
       - success
       type: object
       properties:
         data:
-          required:
-          - items
           type: object
-          properties:
-            items:
-              type: array
-              description: 워크스페이스 목록
-              items:
-                required:
-                - id
-                - name
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: 워크스페이스 이름
-                  description:
-                    type: string
-                    description: 워크스페이스 설명
-                    nullable: true
-                  id:
-                    type: number
-                    description: 워크스페이스 ID
           description: 응답 데이터
         success:
           type: boolean
@@ -2252,19 +2168,6 @@ components:
         message:
           type: string
           description: 메시지
-          nullable: true
-    CreateWorkspaceRequest:
-      title: CreateWorkspaceRequest
-      required:
-      - name
-      type: object
-      properties:
-        name:
-          type: string
-          description: 워크스페이스 이름
-        description:
-          type: string
-          description: 워크스페이스 설명
           nullable: true
     ProblemDetail-NotFound:
       title: ProblemDetail-NotFound
@@ -2299,6 +2202,19 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    CreateWorkspaceRequest:
+      title: CreateWorkspaceRequest
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: 워크스페이스 이름
+        description:
+          type: string
+          description: 워크스페이스 설명
+          nullable: true
     SignupRequest:
       title: SignupRequest
       required:
@@ -2483,39 +2399,6 @@ components:
           type: string
           description: 메시지
           nullable: true
-    ProblemDetail-MissingParameter:
-      title: ProblemDetail-MissingParameter
-      required:
-      - detail
-      - exception
-      - status
-      - timestamp
-      - title
-      - type
-      type: object
-      properties:
-        exception:
-          type: string
-          description: 예외 클래스명
-        instance:
-          type: string
-          description: 오류 인스턴스
-          nullable: true
-        detail:
-          type: string
-          description: 오류 상세 메시지
-        title:
-          type: string
-          description: 에러 코드
-        type:
-          type: string
-          description: 오류 문서 URI
-        timestamp:
-          type: string
-          description: 발생 시각
-        status:
-          type: number
-          description: HTTP 상태 코드
     ApiResponse-BoardDetail:
       title: ApiResponse-BoardDetail
       required:
@@ -2628,25 +2511,8 @@ components:
           type: string
           description: 워크스페이스 설명
           nullable: true
-    ApiResponse-CommentList:
-      title: ApiResponse-CommentList
-      required:
-      - data
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          description: 응답 데이터
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 메시지
-          nullable: true
-    ApiResponse-WorkspaceSearch:
-      title: ApiResponse-WorkspaceSearch
+    ApiResponse-WorkspaceMyPage:
+      title: ApiResponse-WorkspaceMyPage
       required:
       - data
       - success
@@ -2714,6 +2580,50 @@ components:
           type: string
           description: 메시지
           nullable: true
+    ApiResponse-CommentList:
+      title: ApiResponse-CommentList
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
+    ApiResponse-PresignedUrlResponse:
+      title: ApiResponse-PresignedUrlResponse
+      required:
+      - data
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - imageUrl
+          - presignedUrl
+          type: object
+          properties:
+            imageUrl:
+              type: string
+              description: 업로드 완료 후 이미지 접근 URL
+            presignedUrl:
+              type: string
+              description: S3 업로드용 Presigned URL
+          description: 응답 데이터
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 메시지
+          nullable: true
     ProblemDetail-InvalidParameter:
       title: ProblemDetail-InvalidParameter
       required:
@@ -2747,33 +2657,6 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
-    ApiResponse-PresignedUrlResponse:
-      title: ApiResponse-PresignedUrlResponse
-      required:
-      - data
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - imageUrl
-          - presignedUrl
-          type: object
-          properties:
-            imageUrl:
-              type: string
-              description: 업로드 완료 후 이미지 접근 URL
-            presignedUrl:
-              type: string
-              description: S3 업로드용 Presigned URL
-          description: 응답 데이터
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 메시지
-          nullable: true
     ApiResponse-WorkspaceResponse:
       title: ApiResponse-WorkspaceResponse
       required:

--- a/src/test/java/com/ujax/infrastructure/web/submission/SubmissionControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/submission/SubmissionControllerTest.java
@@ -22,7 +22,6 @@ import com.ujax.support.TestSecurityConfig;
 import com.ujax.infrastructure.web.submission.dto.SubmissionRequest;
 import com.ujax.support.TestSecurityConfig;
 
-@Import(TestSecurityConfig.class)
 @WebMvcTest(SubmissionController.class)
 @Import(TestSecurityConfig.class)
 class SubmissionControllerTest {


### PR DESCRIPTION
# 관련 작업 / 이슈

> 관련된 이슈나 작업 번호를 링크해 주세요.

x

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

- 워크스페이스 목록 조회 엔드포인트를 /me로 변경 반영
- /search 엔드포인트 제거 및 /explore에 name 파라미터 추가
- PresignedUrl 응답 스키마 추가
- SubmissionControllerTest 중복 @Import 제거

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명: x

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [ ] Yes (호환성 깨짐 있음)
- [x] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO:
- 추후 리팩터링/성능 개선 포인트:
- 다른 모듈/서비스와의 의존성 또는 영향:

