### PR TITLE
[SECURITY] 워크스페이스 설정 조회 시 hookUrl 원문 노출 방지

### DIFF
--- a/src/main/java/com/ujax/application/workspace/dto/response/WorkspaceSettingsResponse.java
+++ b/src/main/java/com/ujax/application/workspace/dto/response/WorkspaceSettingsResponse.java
@@ -28,9 +28,24 @@ public record WorkspaceSettingsResponse(
 			return hookUrl;
 		}
 
-		int maskStartIndex = findMaskStartIndex(hookUrl);
-		int maskedLength = hookUrl.length() - maskStartIndex;
-		return hookUrl.substring(0, maskStartIndex) + String.valueOf(MASK_CHAR).repeat(maskedLength);
+		int secretStartIndex = findMaskStartIndex(hookUrl);
+		String visiblePrefix = hookUrl.substring(0, secretStartIndex);
+		String secret = hookUrl.substring(secretStartIndex);
+		return visiblePrefix + maskMiddleHalf(secret);
+	}
+
+	private static String maskMiddleHalf(String value) {
+		if (value.isEmpty()) {
+			return value;
+		}
+
+		int maskedLength = Math.max(1, value.length() / 2);
+		int maskStartIndex = (value.length() - maskedLength) / 2;
+		int maskEndIndex = maskStartIndex + maskedLength;
+
+		return value.substring(0, maskStartIndex)
+			+ String.valueOf(MASK_CHAR).repeat(maskedLength)
+			+ value.substring(maskEndIndex);
 	}
 
 	private static int findMaskStartIndex(String hookUrl) {
@@ -40,7 +55,7 @@ public record WorkspaceSettingsResponse(
 		}
 
 		int lastSlashIndex = hookUrl.lastIndexOf('/');
-		if (lastSlashIndex >= 0 && lastSlashIndex + 1 < hookUrl.length()) {
+		if (lastSlashIndex >= 0) {
 			return lastSlashIndex + 1;
 		}
 

--- a/src/test/java/com/ujax/application/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/com/ujax/application/workspace/WorkspaceServiceTest.java
@@ -1061,7 +1061,7 @@ class WorkspaceServiceTest {
 				.containsExactly(
 					workspace.getId(),
 					Workspace.DEFAULT_WORKSPACE_IMAGE_URL,
-					"https://meeting.ssafy.com/hooks/**************************"
+					"https://meeting.ssafy.com/hooks/j8ki3j*************e9ak9jh"
 				);
 		}
 

--- a/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerDocsTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerDocsTest.java
@@ -406,7 +406,7 @@ class WorkspaceControllerDocsTest {
 			"워크스페이스",
 			"소개",
 			"https://image.example.com/workspaces/1.png",
-			"https://meeting.ssafy.com/hooks/**************************"
+			"https://meeting.ssafy.com/hooks/j8ki3j*************e9ak9jh"
 		);
 		given(workspaceService.getWorkspaceSettings(anyLong(), anyLong())).willReturn(response);
 

--- a/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerTest.java
+++ b/src/test/java/com/ujax/infrastructure/web/api/workspace/WorkspaceControllerTest.java
@@ -243,7 +243,7 @@ class WorkspaceControllerTest {
 				"알고리즘 스터디",
 				"소개",
 				"https://image.example.com/workspaces/3.png",
-				"https://meeting.ssafy.com/hooks/**************************"
+				"https://meeting.ssafy.com/hooks/j8ki3j*************e9ak9jh"
 			);
 			given(workspaceService.getWorkspaceSettings(anyLong(), anyLong())).willReturn(response);
 
@@ -253,7 +253,7 @@ class WorkspaceControllerTest {
 				.andExpect(jsonPath("$.success").value(true))
 				.andExpect(jsonPath("$.data.id").value(3))
 				.andExpect(jsonPath("$.data.imageUrl").value("https://image.example.com/workspaces/3.png"))
-				.andExpect(jsonPath("$.data.hookUrl").value("https://meeting.ssafy.com/hooks/**************************"));
+				.andExpect(jsonPath("$.data.hookUrl").value("https://meeting.ssafy.com/hooks/j8ki3j*************e9ak9jh"));
 
 			then(workspaceService).should().getWorkspaceSettings(3L, 1L);
 		}


### PR DESCRIPTION
# 관련 작업 / 이슈

- #33

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

- 내용:
  - 워크스페이스 설정 조회 응답의 `hookUrl`을 원문 대신 마스킹된 문자열로 반환하도록 변경했습니다.
  - `hooks/` 뒤 비밀값 전체를 숨기지 않고, 가운데 절반 정도만 `*`로 가려 앞/뒤 일부만 보이도록 조정했습니다.
  - 서비스/API/문서 테스트 기대값을 마스킹 정책에 맞게 갱신했습니다.

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명:
  - `./gradlew verify`
  - 워크스페이스 설정 조회 서비스/컨트롤러/문서 테스트를 포함한 전체 검증 통과

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [ ] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [x] Yes (호환성 깨짐 있음)
- [ ] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

- `GET /api/v1/workspaces/{workspaceId}/settings` 의 `hookUrl`이 더 이상 원문을 반환하지 않습니다.
- 설정 화면에서 기존 `hookUrl` 원문을 응답값으로 재사용해 수정 폼에 채우던 클라이언트가 있다면 별도 처리 또는 UX 조정이 필요합니다.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.

- 없음

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO:
  - 필요 시 설정 수정 UX에서 마스킹된 값과 실제 저장값을 분리해 다루는 정책 정리
- 추후 리팩터링/성능 개선 포인트:
  - 민감정보 응답/로그 마스킹 정책을 공통 유틸로 추출 가능
- 다른 모듈/서비스와의 의존성 또는 영향:
  - 워크스페이스 설정 조회 응답을 사용하는 프론트엔드 화면
