### PR TITLE
fix: 웹훅 문제 링크를 IDE 경로로 수정

### DIFF
--- a/src/main/java/com/ujax/application/webhook/WebhookAlertService.java
+++ b/src/main/java/com/ujax/application/webhook/WebhookAlertService.java
@@ -370,19 +370,17 @@ public class WebhookAlertService {
 			alert.getScheduledAt(),
 			buildWorkspaceProblemLink(
 				alert.getWorkspaceId(),
-				workspaceProblem.getProblemBox().getId(),
-				workspaceProblem.getId()
+				workspaceProblem.getProblem().getProblemNumber()
 			)
 		);
 	}
 
 	private String buildWorkspaceLink(Long workspaceId) {
-		return "%s/workspaces/%d".formatted(baseUrl, workspaceId);
+		return "%s/ws/%d/dashboard".formatted(baseUrl, workspaceId);
 	}
 
-	private String buildWorkspaceProblemLink(Long workspaceId, Long problemBoxId, Long workspaceProblemId) {
-		return "%s/workspaces/%d/problem-boxes/%d/problems/%d"
-			.formatted(baseUrl, workspaceId, problemBoxId, workspaceProblemId);
+	private String buildWorkspaceProblemLink(Long workspaceId, int problemNumber) {
+		return "%s/ws/%d/ide/%d".formatted(baseUrl, workspaceId, problemNumber);
 	}
 
 }

--- a/src/test/java/com/ujax/application/webhook/WebhookAlertServiceTest.java
+++ b/src/test/java/com/ujax/application/webhook/WebhookAlertServiceTest.java
@@ -410,7 +410,7 @@ class WebhookAlertServiceTest {
 						&& message.deadline().equals(LocalDateTime.of(2026, 3, 8, 12, 0))
 						&& message.scheduledAt().equals(LocalDateTime.of(2026, 3, 8, 9, 0))
 						&& message.problemLink().equals(
-							"https://ujax.site/workspaces/11/problem-boxes/7/problems/101"
+							"https://ujax.site/ws/11/ide/1000"
 						)
 				)
 			);

--- a/src/test/java/com/ujax/infrastructure/external/webhook/RestTemplateWebhookSenderTest.java
+++ b/src/test/java/com/ujax/infrastructure/external/webhook/RestTemplateWebhookSenderTest.java
@@ -40,7 +40,7 @@ class RestTemplateWebhookSenderTest {
 				    {
 				      "color": "#2563EB",
 				      "title": "[알고리즘 스터디] 1000. 백준 1000 A+B",
-				      "title_link": "https://ujax.site/workspaces/11/problem-boxes/7/problems/101",
+				      "title_link": "https://ujax.site/ws/11/ide/1000",
 				      "text": "### 문제 풀이 마감까지 얼마 남지 않았습니다.\\n\\n**마감일**\\n\\n**03월 08일 11:00**",
 				      "footer": "프로젝트명"
 				    }
@@ -51,7 +51,7 @@ class RestTemplateWebhookSenderTest {
 				  "problemTitle": "1000. 백준 1000 A+B",
 				  "deadline": "2026-03-08T11:00:00",
 				  "scheduledAt": "2026-03-08T10:00:00",
-				  "problemLink": "https://ujax.site/workspaces/11/problem-boxes/7/problems/101"
+				  "problemLink": "https://ujax.site/ws/11/ide/1000"
 				}
 				"""))
 			.andRespond(withSuccess());
@@ -65,7 +65,7 @@ class RestTemplateWebhookSenderTest {
 				"1000. 백준 1000 A+B",
 				LocalDateTime.of(2026, 3, 8, 11, 0),
 				LocalDateTime.of(2026, 3, 8, 10, 0),
-				"https://ujax.site/workspaces/11/problem-boxes/7/problems/101"
+				"https://ujax.site/ws/11/ide/1000"
 			)
 		);
 
@@ -88,7 +88,7 @@ class RestTemplateWebhookSenderTest {
 				"1000. 백준 1000 A+B",
 				LocalDateTime.of(2026, 3, 8, 11, 0),
 				LocalDateTime.of(2026, 3, 8, 10, 0),
-				"https://ujax.site/workspaces/11/problem-boxes/7/problems/101"
+				"https://ujax.site/ws/11/ide/1000"
 			)
 		)).isInstanceOf(HttpServerErrorException.class);
 


### PR DESCRIPTION
# 관련 작업 / 이슈

> 관련된 이슈나 작업 번호를 링크해 주세요.

- 없음

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

- 내용:
  - 웹훅 알림의 문제 링크를 `workspaceProblemId` 기반 구경로에서 `problemNumber` 기반 IDE 경로(`/ws/{workspaceId}/ide/{problemNumber}`)로 수정했습니다.
  - 알림 payload 및 웹훅 서비스 테스트를 새 링크 포맷에 맞게 갱신했습니다.

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명:
  - `./gradlew verify`
  - `./gradlew test --tests 'com.ujax.application.webhook.WebhookAlertServiceTest' --tests 'com.ujax.infrastructure.external.webhook.RestTemplateWebhookSenderTest'`

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [ ] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [ ] Yes (호환성 깨짐 있음)
- [x] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.

- 로컬 `./gradlew verify` 통과

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO: 초대 메일 링크도 프론트 라우트 체계와 일치하는지 별도 점검 필요
- 추후 리팩터링/성능 개선 포인트: 없음
- 다른 모듈/서비스와의 의존성 또는 영향: 웹훅을 수신하는 외부 채널에서 클릭 시 프론트 IDE 경로로 이동
