### PR TITLE
fix: 워크스페이스 문제 deadline 과거 시각 검증 추가

### DIFF
--- a/src/main/java/com/ujax/application/problem/WorkspaceProblemService.java
+++ b/src/main/java/com/ujax/application/problem/WorkspaceProblemService.java
@@ -62,6 +62,7 @@ public class WorkspaceProblemService {
 	public WorkspaceProblemResponse createWorkspaceProblem(Long workspaceId, Long problemBoxId, Long userId,
 		CreateWorkspaceProblemRequest request) {
 		WorkspaceMember member = findManagerOrOwner(workspaceId, userId);
+		LocalDateTime now = LocalDateTime.now();
 
 		ProblemBox problemBox = findProblemBox(problemBoxId, workspaceId);
 		Problem problem = problemRepository.findById(request.problemId())
@@ -70,8 +71,11 @@ public class WorkspaceProblemService {
 		if (workspaceProblemRepository.existsByProblemBox_IdAndProblem_Id(problemBoxId, problem.getId())) {
 			throw new ConflictException(ErrorCode.DUPLICATE_WORKSPACE_PROBLEM);
 		}
+		if (request.deadline() != null) {
+			validateDeadline(request.deadline(), now);
+		}
 		if (request.scheduledAt() != null) {
-			validateScheduledAt(request.scheduledAt());
+			validateScheduledAt(request.scheduledAt(), now);
 			validateWorkspaceHookUrl(member.getWorkspace());
 		}
 
@@ -95,11 +99,15 @@ public class WorkspaceProblemService {
 	public WorkspaceProblemResponse updateWorkspaceProblem(Long workspaceId, Long problemBoxId,
 		Long workspaceProblemId, Long userId, UpdateWorkspaceProblemRequest request) {
 		WorkspaceMember member = findManagerOrOwner(workspaceId, userId);
+		LocalDateTime now = LocalDateTime.now();
 
 		WorkspaceProblem workspaceProblem = findWorkspaceProblem(workspaceId, workspaceProblemId, problemBoxId);
 
+		if (request.deadline() != null) {
+			validateDeadline(request.deadline(), now);
+		}
 		if (request.scheduledAt() != null) {
-			validateScheduledAt(request.scheduledAt());
+			validateScheduledAt(request.scheduledAt(), now);
 			validateWorkspaceHookUrl(member.getWorkspace());
 		}
 
@@ -156,8 +164,14 @@ public class WorkspaceProblemService {
 		}
 	}
 
-	private void validateScheduledAt(LocalDateTime scheduledAt) {
-		if (scheduledAt.isBefore(LocalDateTime.now().plusMinutes(MIN_SCHEDULE_LEAD_MINUTES))) {
+	private void validateDeadline(LocalDateTime deadline, LocalDateTime now) {
+		if (deadline.isBefore(now)) {
+			throw new BusinessRuleViolationException("deadline은 현재 시각보다 이전일 수 없습니다.");
+		}
+	}
+
+	private void validateScheduledAt(LocalDateTime scheduledAt, LocalDateTime now) {
+		if (scheduledAt.isBefore(now.plusMinutes(MIN_SCHEDULE_LEAD_MINUTES))) {
 			throw new BusinessRuleViolationException(
 				"scheduledAt은 현재 시각 기준 %d분 이후여야 합니다.".formatted(MIN_SCHEDULE_LEAD_MINUTES)
 			);

--- a/src/test/java/com/ujax/application/problem/WorkspaceProblemServiceTest.java
+++ b/src/test/java/com/ujax/application/problem/WorkspaceProblemServiceTest.java
@@ -143,7 +143,7 @@ class WorkspaceProblemServiceTest {
 			createMember(workspace, user, WorkspaceMemberRole.OWNER);
 			ProblemBox problemBox = createProblemBox(workspace);
 			Problem problem = createProblem(1000, "A+B");
-			LocalDateTime deadline = LocalDateTime.of(2026, 3, 1, 0, 0);
+			LocalDateTime deadline = LocalDateTime.now().plusDays(1);
 
 			WorkspaceProblemResponse response = workspaceProblemService.createWorkspaceProblem(
 				workspace.getId(), problemBox.getId(), user.getId(),
@@ -151,6 +151,24 @@ class WorkspaceProblemServiceTest {
 
 			assertThat(response).extracting("problemNumber", "title", "deadline")
 				.containsExactly(1000, "A+B", deadline);
+			then(webhookAlertService).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("deadline이 현재 시각보다 이전이면 오류가 발생한다")
+		void createWithPastDeadline() {
+			User user = createUser("owner@example.com");
+			Workspace workspace = createWorkspace();
+			createMember(workspace, user, WorkspaceMemberRole.OWNER);
+			ProblemBox problemBox = createProblemBox(workspace);
+			Problem problem = createProblem(1000, "A+B");
+			LocalDateTime deadline = LocalDateTime.now().minusMinutes(1);
+
+			assertThatThrownBy(() -> workspaceProblemService.createWorkspaceProblem(
+				workspace.getId(), problemBox.getId(), user.getId(),
+				new CreateWorkspaceProblemRequest(problem.getId(), deadline, null)))
+				.isInstanceOf(BusinessRuleViolationException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.BUSINESS_RULE_VIOLATION);
 			then(webhookAlertService).shouldHaveNoInteractions();
 		}
 
@@ -297,7 +315,7 @@ class WorkspaceProblemServiceTest {
 				workspace.getId(), problemBox.getId(), user.getId(),
 				new CreateWorkspaceProblemRequest(problem.getId(), null, null));
 
-			LocalDateTime newDeadline = LocalDateTime.of(2026, 4, 1, 0, 0);
+			LocalDateTime newDeadline = LocalDateTime.now().plusDays(7);
 			LocalDateTime newScheduledAt = LocalDateTime.now().plusDays(1);
 
 			WorkspaceProblemResponse response = workspaceProblemService.updateWorkspaceProblem(
@@ -308,6 +326,28 @@ class WorkspaceProblemServiceTest {
 				.containsExactly(newDeadline, newScheduledAt);
 			then(webhookAlertService).should()
 				.reserveOrUpdate(created.id(), workspace.getId(), newScheduledAt, user.getId());
+		}
+
+		@Test
+		@DisplayName("deadline을 현재 시각보다 이전으로 수정하면 오류가 발생한다")
+		void updateWithPastDeadline() {
+			User user = createUser("owner@example.com");
+			Workspace workspace = createWorkspace();
+			createMember(workspace, user, WorkspaceMemberRole.OWNER);
+			ProblemBox problemBox = createProblemBox(workspace);
+			Problem problem = createProblem(1000, "A+B");
+
+			WorkspaceProblemResponse created = workspaceProblemService.createWorkspaceProblem(
+				workspace.getId(), problemBox.getId(), user.getId(),
+				new CreateWorkspaceProblemRequest(problem.getId(), null, null));
+			LocalDateTime deadline = LocalDateTime.now().minusMinutes(1);
+
+			assertThatThrownBy(() -> workspaceProblemService.updateWorkspaceProblem(
+				workspace.getId(), problemBox.getId(), created.id(), user.getId(),
+				new UpdateWorkspaceProblemRequest(deadline, null)))
+				.isInstanceOf(BusinessRuleViolationException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.BUSINESS_RULE_VIOLATION);
+			then(webhookAlertService).shouldHaveNoInteractions();
 		}
 
 		@Test


### PR DESCRIPTION
# 관련 작업 / 이슈

close #61

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

- 내용:
  - 워크스페이스 문제 생성/수정 시 `deadline`이 현재 시각보다 이전이면 `BusinessRuleViolationException`을 반환하도록 검증을 추가했습니다.
  - `scheduledAt` 검증도 같은 `now` 기준을 사용하도록 정리했습니다.
  - 서비스 테스트에 과거 `deadline` 생성/수정 실패 케이스를 추가하고, 기존 성공 테스트는 상대 시각 기반으로 바꿔 시점 의존성을 제거했습니다.

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.
- 테스트 시나리오 설명:
  - `./gradlew verify`
  - 워크스페이스 문제 생성 시 과거 `deadline` 입력 실패
  - 워크스페이스 문제 수정 시 과거 `deadline` 입력 실패
  - 기존 `scheduledAt` 검증 및 정상 생성/수정 시나리오 회귀 확인

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [ ] Yes (호환성 깨짐 있음)
- [x] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.

- `./gradlew verify` 통과

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO: 프론트 입력 단계에서도 과거 `deadline` 선택을 막고 있다면 에러 메시지와 정책을 서버와 맞출 수 있습니다.
- 추후 리팩터링/성능 개선 포인트: 시간 기준 검증이 늘어나면 Clock 주입 방식으로 테스트 안정성을 더 높일 수 있습니다.
- 다른 모듈/서비스와의 의존성 또는 영향: 대시보드 마감 집계와 deadline 기반 통계의 데이터 무결성이 개선됩니다.
