### PR TITLE
FEAT: 도메인 인덱스 및 Flyway

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,7 +21,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://app-mysql:3306/ujax?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:-ujax}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-ujax_password_secure}
-      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SPRING_JPA_HIBERNATE_DDL_AUTO: validate
+      SPRING_FLYWAY_ENABLED: true
       SPRING_DATA_REDIS_HOST: app-redis
       SPRING_DATA_REDIS_PORT: 6379
       JUDGE0_API_URL: http://${JUDGE0_HOST}:2358

--- a/src/main/java/com/ujax/domain/board/Board.java
+++ b/src/main/java/com/ujax/domain/board/Board.java
@@ -15,6 +15,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,7 +26,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "boards")
+@Table(
+	name = "boards",
+	indexes = {
+		@Index(name = "idx_boards_workspace_created_id", columnList = "workspace_id,created_at,id")
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/board/BoardComment.java
+++ b/src/main/java/com/ujax/domain/board/BoardComment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "board_comments")
+@Table(
+	name = "board_comments",
+	indexes = {
+		@Index(name = "idx_board_comments_board_id", columnList = "board_id")
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/problem/ProblemBox.java
+++ b/src/main/java/com/ujax/domain/problem/ProblemBox.java
@@ -13,6 +13,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "problem_box")
+@Table(
+	name = "problem_box",
+	indexes = {
+		@Index(name = "idx_problem_box_workspace_updated_id", columnList = "workspace_id,updated_at,id")
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/problem/WorkspaceProblem.java
+++ b/src/main/java/com/ujax/domain/problem/WorkspaceProblem.java
@@ -13,6 +13,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "workspace_problem")
+@Table(
+	name = "workspace_problem",
+	indexes = {
+		@Index(name = "idx_workspace_problem_problem_box_id", columnList = "problem_box_id")
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/solution/Solution.java
+++ b/src/main/java/com/ujax/domain/solution/Solution.java
@@ -15,6 +15,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,7 +25,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "solution")
+@Table(
+	name = "solution",
+	indexes = {
+		@Index(
+			name = "idx_solution_workspace_problem_created_id",
+			columnList = "workspace_problem_id,created_at,id"
+		)
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/solution/SolutionComment.java
+++ b/src/main/java/com/ujax/domain/solution/SolutionComment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "solution_comments")
+@Table(
+	name = "solution_comments",
+	indexes = {
+		@Index(name = "idx_solution_comments_solution_created_id", columnList = "solution_id,created_at,id")
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"

--- a/src/main/java/com/ujax/domain/user/User.java
+++ b/src/main/java/com/ujax/domain/user/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "users")
+@Table(
+	name = "users",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_users_provider_provider_id",
+			columnNames = {"provider", "provider_id"}
+		)
+	}
+)
 @Filter(
 	name = "softDeleteFilter",
 	condition = "deleted_at IS NULL"
@@ -55,6 +64,7 @@ public class User extends BaseEntity {
 	private AuthProvider provider;
 
 	/** OAuth 식별자 (자체 회원가입시 null) */
+	@Column(name = "provider_id")
 	private String providerId;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/ujax/domain/webhook/WebhookAlert.java
+++ b/src/main/java/com/ujax/domain/webhook/WebhookAlert.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 	name = "webhook_alert",
 	indexes = {
 		@Index(name = "idx_webhook_alert_due", columnList = "status,scheduled_at"),
-		@Index(name = "idx_webhook_alert_workspace", columnList = "workspace_id")
+		@Index(name = "idx_webhook_alert_status_updated_at", columnList = "status,updated_at")
 	},
 	uniqueConstraints = {
 		@UniqueConstraint(

--- a/src/main/java/com/ujax/domain/webhook/WebhookAlertLog.java
+++ b/src/main/java/com/ujax/domain/webhook/WebhookAlertLog.java
@@ -26,9 +26,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "webhook_alert_log",
 	indexes = {
-		@Index(name = "idx_webhook_alert_log_alert_created", columnList = "webhook_alert_id,created_at"),
-		@Index(name = "idx_webhook_alert_log_workspace_problem_created", columnList = "workspace_problem_id,created_at"),
-		@Index(name = "idx_webhook_alert_log_event_created", columnList = "event_type,created_at")
+		@Index(name = "idx_webhook_alert_log_workspace_problem_created", columnList = "workspace_problem_id,created_at")
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ujax/domain/workspace/WorkspaceJoinRequest.java
+++ b/src/main/java/com/ujax/domain/workspace/WorkspaceJoinRequest.java
@@ -32,8 +32,7 @@ import lombok.NoArgsConstructor;
 		@UniqueConstraint(name = "uk_wjr_workspace_user", columnNames = {"workspace_id", "user_id"})
 	},
 	indexes = {
-		@Index(name = "idx_wjr_workspace_created_at", columnList = "workspace_id,created_at"),
-		@Index(name = "idx_wjr_user_created_at", columnList = "user_id,created_at")
+		@Index(name = "idx_wjr_workspace_created_at", columnList = "workspace_id,created_at")
 	}
 )
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/ujax/domain/workspace/WorkspaceMember.java
+++ b/src/main/java/com/ujax/domain/workspace/WorkspaceMember.java
@@ -19,6 +19,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -31,7 +32,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(
 	name = "workspace_members",
-	uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "user_id"})
+	uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "user_id"}),
+	indexes = {
+		@Index(name = "idx_workspace_members_user_id", columnList = "user_id")
+	}
 )
 @Filter(
 	name = "softDeleteFilter",

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -44,3 +44,13 @@ spring.security.oauth2.client:
     kakao:
       redirect-uri: http://localhost:8080/login/oauth2/code/kakao
 
+server:
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: on_param
+
+logging:
+  level:
+    root: INFO
+    com.ujax: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,48 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://app-mysql:3306/ujax?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false}
+    username: ${SPRING_DATASOURCE_USERNAME:ujax}
+    password: ${SPRING_DATASOURCE_PASSWORD:ujax_password_secure}
+    hikari:
+      maximum-pool-size: ${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE:32}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  flyway:
+    enabled: true
+
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:app-redis}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+
+judge0:
+  api:
+    url: ${JUDGE0_API_URL:http://judge0-server:2358}
+
+spring.security.oauth2.client:
+  registration:
+    google:
+      redirect-uri: ${GOOGLE_REDIRECT_URI}
+    kakao:
+      redirect-uri: ${KAKAO_REDIRECT_URI}
+
+server:
+  error:
+    include-message: never
+    include-binding-errors: never
+    include-stacktrace: never
+
+logging:
+  level:
+    root: INFO
+    com.ujax: INFO
+    org.springframework.security: WARN
+    org.hibernate.SQL: WARN

--- a/src/main/resources/db/migration/V1__baseline_schema.sql
+++ b/src/main/resources/db/migration/V1__baseline_schema.sql
@@ -1,0 +1,397 @@
+CREATE TABLE users (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    email VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NULL,
+    name VARCHAR(30) NOT NULL,
+    profile_image_url VARCHAR(255) NULL,
+    provider ENUM('GOOGLE', 'KAKAO', 'LOCAL') NOT NULL,
+    provider_id VARCHAR(255) NULL,
+    role ENUM('ADMIN', 'USER') NOT NULL,
+    baekjoon_id VARCHAR(255) NULL,
+    CONSTRAINT pk_users PRIMARY KEY (id),
+    CONSTRAINT uk_users_email UNIQUE (email),
+    CONSTRAINT uk_users_provider_provider_id UNIQUE (provider, provider_id)
+);
+
+CREATE TABLE refresh_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    token_hash VARCHAR(255) NOT NULL,
+    expires_at DATETIME(6) NOT NULL,
+    revoked_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    CONSTRAINT pk_refresh_tokens PRIMARY KEY (id),
+    CONSTRAINT uk_refresh_tokens_token_hash UNIQUE (token_hash)
+);
+
+CREATE TABLE workspaces (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    name VARCHAR(50) NOT NULL,
+    description VARCHAR(200) NULL,
+    hook_url VARCHAR(255) NULL,
+    image_url VARCHAR(500) NULL,
+    CONSTRAINT pk_workspaces PRIMARY KEY (id)
+);
+
+CREATE TABLE workspace_members (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    role ENUM('MANAGER', 'MEMBER', 'OWNER') NOT NULL,
+    nickname VARCHAR(30) NOT NULL,
+    last_activity_date DATE NULL,
+    current_streak_days INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_workspace_members PRIMARY KEY (id),
+    CONSTRAINT uk_workspace_members_workspace_user UNIQUE (workspace_id, user_id)
+);
+
+CREATE TABLE workspace_join_requests (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    CONSTRAINT pk_workspace_join_requests PRIMARY KEY (id),
+    CONSTRAINT uk_wjr_workspace_user UNIQUE (workspace_id, user_id)
+);
+
+CREATE TABLE boards (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    type ENUM('DATA', 'FREE', 'NOTICE', 'QNA') NOT NULL,
+    is_pinned BIT NOT NULL,
+    title VARCHAR(50) NOT NULL,
+    content VARCHAR(2000) NOT NULL,
+    view_count BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_boards PRIMARY KEY (id)
+);
+
+CREATE TABLE board_comments (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    board_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    content VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_board_comments PRIMARY KEY (id)
+);
+
+CREATE TABLE board_likes (
+    board_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    is_deleted BIT NOT NULL,
+    CONSTRAINT pk_board_likes PRIMARY KEY (board_id, workspace_member_id)
+);
+
+CREATE TABLE problem (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    problem_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    tier VARCHAR(255) NULL,
+    time_limit VARCHAR(255) NULL,
+    memory_limit VARCHAR(255) NULL,
+    description TEXT NULL,
+    input_description TEXT NULL,
+    output_description TEXT NULL,
+    url VARCHAR(255) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_problem PRIMARY KEY (id),
+    CONSTRAINT uk_problem_problem_number UNIQUE (problem_number)
+);
+
+CREATE TABLE algorithm_tag (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    name VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_algorithm_tag PRIMARY KEY (id),
+    CONSTRAINT uk_algorithm_tag_name UNIQUE (name)
+);
+
+CREATE TABLE problem_box (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_id BIGINT NOT NULL,
+    title VARCHAR(30) NOT NULL,
+    description VARCHAR(255) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_problem_box PRIMARY KEY (id)
+);
+
+CREATE TABLE sample (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    problem_id BIGINT NOT NULL,
+    sample_index INT NOT NULL,
+    input TEXT NULL,
+    output TEXT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_sample PRIMARY KEY (id),
+    CONSTRAINT uk_sample_problem_sample_index UNIQUE (problem_id, sample_index)
+);
+
+CREATE TABLE problem_algorithm (
+    problem_id BIGINT NOT NULL,
+    algorithm_id BIGINT NOT NULL
+);
+
+CREATE TABLE workspace_problem (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    problem_box_id BIGINT NOT NULL,
+    problem_id BIGINT NOT NULL,
+    deadline DATETIME(6) NULL,
+    scheduled_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_workspace_problem PRIMARY KEY (id)
+);
+
+CREATE TABLE solution (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_problem_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    submission_id BIGINT NOT NULL,
+    status ENUM(
+        'ACCEPTED',
+        'COMPILE_ERROR',
+        'MEMORY_LIMIT_EXCEEDED',
+        'OTHER',
+        'OUTPUT_LIMIT_EXCEEDED',
+        'PARTIAL_ACCEPTED',
+        'PRESENTATION_ERROR',
+        'RUNTIME_ERROR',
+        'TIME_LIMIT_EXCEEDED',
+        'WRONG_ANSWER'
+    ) NOT NULL,
+    time VARCHAR(255) NULL,
+    memory VARCHAR(255) NULL,
+    programming_language ENUM(
+        'C',
+        'CPP',
+        'CSHARP',
+        'GO',
+        'JAVA',
+        'JAVASCRIPT',
+        'KOTLIN',
+        'OTHER',
+        'PYTHON',
+        'RUBY',
+        'RUST',
+        'SWIFT'
+    ) NULL,
+    code_length VARCHAR(255) NULL,
+    code MEDIUMTEXT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_solution PRIMARY KEY (id),
+    CONSTRAINT uk_solution_submission_id UNIQUE (submission_id)
+);
+
+CREATE TABLE solution_comments (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    solution_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    content VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    deleted_at DATETIME(6) NULL,
+    CONSTRAINT pk_solution_comments PRIMARY KEY (id)
+);
+
+CREATE TABLE solution_likes (
+    solution_id BIGINT NOT NULL,
+    workspace_member_id BIGINT NOT NULL,
+    is_deleted BIT NOT NULL,
+    CONSTRAINT pk_solution_likes PRIMARY KEY (solution_id, workspace_member_id)
+);
+
+CREATE TABLE webhook_alert (
+    webhook_alert_id BIGINT NOT NULL AUTO_INCREMENT,
+    workspace_problem_id BIGINT NOT NULL,
+    workspace_id BIGINT NOT NULL,
+    scheduled_at DATETIME(6) NOT NULL,
+    next_scheduled_at DATETIME(6) NULL,
+    status ENUM('PENDING', 'PROCESSING') NOT NULL,
+    attempt_no INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    CONSTRAINT pk_webhook_alert PRIMARY KEY (webhook_alert_id),
+    CONSTRAINT uk_webhook_alert_workspace_problem UNIQUE (workspace_problem_id)
+);
+
+CREATE TABLE webhook_alert_log (
+    webhook_alert_log_id BIGINT NOT NULL AUTO_INCREMENT,
+    webhook_alert_id BIGINT NULL,
+    workspace_problem_id BIGINT NOT NULL,
+    workspace_id BIGINT NOT NULL,
+    event_type ENUM(
+        'CANCELLED',
+        'CREATED',
+        'DEACTIVATED',
+        'DEFERRED_SCHEDULED',
+        'DELIVERED',
+        'FAILED',
+        'PROCESSING_STARTED',
+        'RECOVERED',
+        'RETRY_SCHEDULED',
+        'SCHEDULE_UPDATED'
+    ) NOT NULL,
+    from_status ENUM('PENDING', 'PROCESSING') NULL,
+    to_status ENUM('PENDING', 'PROCESSING') NULL,
+    scheduled_at DATETIME(6) NULL,
+    next_scheduled_at DATETIME(6) NULL,
+    attempt_no INT NULL,
+    send_at DATETIME(6) NULL,
+    last_attempt_at DATETIME(6) NULL,
+    err_msg VARCHAR(255) NULL,
+    actor_type ENUM('BATCH', 'SYSTEM', 'USER') NOT NULL,
+    actor_id BIGINT NULL,
+    created_at DATETIME(6) NOT NULL,
+    CONSTRAINT pk_webhook_alert_log PRIMARY KEY (webhook_alert_log_id)
+);
+
+CREATE INDEX idx_workspace_members_user_id
+    ON workspace_members (user_id);
+
+CREATE INDEX idx_wjr_workspace_created_at
+    ON workspace_join_requests (workspace_id, created_at);
+
+CREATE INDEX idx_boards_workspace_created_id
+    ON boards (workspace_id, created_at, id);
+
+CREATE INDEX idx_board_comments_board_id
+    ON board_comments (board_id);
+
+CREATE INDEX idx_problem_box_workspace_updated_id
+    ON problem_box (workspace_id, updated_at, id);
+
+CREATE INDEX idx_workspace_problem_problem_box_id
+    ON workspace_problem (problem_box_id);
+
+CREATE INDEX idx_solution_workspace_problem_created_id
+    ON solution (workspace_problem_id, created_at, id);
+
+CREATE INDEX idx_solution_comments_solution_created_id
+    ON solution_comments (solution_id, created_at, id);
+
+CREATE INDEX idx_webhook_alert_due
+    ON webhook_alert (status, scheduled_at);
+
+CREATE INDEX idx_webhook_alert_status_updated_at
+    ON webhook_alert (status, updated_at);
+
+CREATE INDEX idx_webhook_alert_log_workspace_problem_created
+    ON webhook_alert_log (workspace_problem_id, created_at);
+
+ALTER TABLE refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_user
+        FOREIGN KEY (user_id) REFERENCES users (id);
+
+ALTER TABLE workspace_members
+    ADD CONSTRAINT fk_workspace_members_workspace
+        FOREIGN KEY (workspace_id) REFERENCES workspaces (id);
+
+ALTER TABLE workspace_members
+    ADD CONSTRAINT fk_workspace_members_user
+        FOREIGN KEY (user_id) REFERENCES users (id);
+
+ALTER TABLE workspace_join_requests
+    ADD CONSTRAINT fk_workspace_join_requests_workspace
+        FOREIGN KEY (workspace_id) REFERENCES workspaces (id);
+
+ALTER TABLE workspace_join_requests
+    ADD CONSTRAINT fk_workspace_join_requests_user
+        FOREIGN KEY (user_id) REFERENCES users (id);
+
+ALTER TABLE boards
+    ADD CONSTRAINT fk_boards_workspace
+        FOREIGN KEY (workspace_id) REFERENCES workspaces (id);
+
+ALTER TABLE boards
+    ADD CONSTRAINT fk_boards_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);
+
+ALTER TABLE board_comments
+    ADD CONSTRAINT fk_board_comments_board
+        FOREIGN KEY (board_id) REFERENCES boards (id);
+
+ALTER TABLE board_comments
+    ADD CONSTRAINT fk_board_comments_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);
+
+ALTER TABLE board_likes
+    ADD CONSTRAINT fk_board_likes_board
+        FOREIGN KEY (board_id) REFERENCES boards (id);
+
+ALTER TABLE board_likes
+    ADD CONSTRAINT fk_board_likes_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);
+
+ALTER TABLE problem_box
+    ADD CONSTRAINT fk_problem_box_workspace
+        FOREIGN KEY (workspace_id) REFERENCES workspaces (id);
+
+ALTER TABLE sample
+    ADD CONSTRAINT fk_sample_problem
+        FOREIGN KEY (problem_id) REFERENCES problem (id);
+
+ALTER TABLE problem_algorithm
+    ADD CONSTRAINT fk_problem_algorithm_problem
+        FOREIGN KEY (problem_id) REFERENCES problem (id);
+
+ALTER TABLE problem_algorithm
+    ADD CONSTRAINT fk_problem_algorithm_algorithm
+        FOREIGN KEY (algorithm_id) REFERENCES algorithm_tag (id);
+
+ALTER TABLE workspace_problem
+    ADD CONSTRAINT fk_workspace_problem_problem_box
+        FOREIGN KEY (problem_box_id) REFERENCES problem_box (id);
+
+ALTER TABLE workspace_problem
+    ADD CONSTRAINT fk_workspace_problem_problem
+        FOREIGN KEY (problem_id) REFERENCES problem (id);
+
+ALTER TABLE solution
+    ADD CONSTRAINT fk_solution_workspace_problem
+        FOREIGN KEY (workspace_problem_id) REFERENCES workspace_problem (id);
+
+ALTER TABLE solution
+    ADD CONSTRAINT fk_solution_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);
+
+ALTER TABLE solution_comments
+    ADD CONSTRAINT fk_solution_comments_solution
+        FOREIGN KEY (solution_id) REFERENCES solution (id);
+
+ALTER TABLE solution_comments
+    ADD CONSTRAINT fk_solution_comments_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);
+
+ALTER TABLE solution_likes
+    ADD CONSTRAINT fk_solution_likes_solution
+        FOREIGN KEY (solution_id) REFERENCES solution (id);
+
+ALTER TABLE solution_likes
+    ADD CONSTRAINT fk_solution_likes_workspace_member
+        FOREIGN KEY (workspace_member_id) REFERENCES workspace_members (id);

--- a/src/test/java/com/ujax/domain/solution/SolutionCommentRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/solution/SolutionCommentRepositoryTest.java
@@ -1,0 +1,162 @@
+package com.ujax.domain.solution;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.domain.problem.Problem;
+import com.ujax.domain.problem.ProblemBox;
+import com.ujax.domain.problem.ProblemBoxRepository;
+import com.ujax.domain.problem.ProblemRepository;
+import com.ujax.domain.problem.WorkspaceProblem;
+import com.ujax.domain.problem.WorkspaceProblemRepository;
+import com.ujax.domain.user.Password;
+import com.ujax.domain.user.User;
+import com.ujax.domain.user.UserRepository;
+import com.ujax.domain.workspace.Workspace;
+import com.ujax.domain.workspace.WorkspaceMember;
+import com.ujax.domain.workspace.WorkspaceMemberRepository;
+import com.ujax.domain.workspace.WorkspaceMemberRole;
+import com.ujax.domain.workspace.WorkspaceRepository;
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class SolutionCommentRepositoryTest {
+
+	@Autowired
+	private SolutionCommentRepository solutionCommentRepository;
+
+	@Autowired
+	private SolutionRepository solutionRepository;
+
+	@Autowired
+	private WorkspaceProblemRepository workspaceProblemRepository;
+
+	@Autowired
+	private ProblemBoxRepository problemBoxRepository;
+
+	@Autowired
+	private ProblemRepository problemRepository;
+
+	@Autowired
+	private WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Autowired
+	private WorkspaceRepository workspaceRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		solutionCommentRepository.deleteAllInBatch();
+		solutionRepository.deleteAllInBatch();
+		workspaceProblemRepository.deleteAllInBatch();
+		problemBoxRepository.deleteAllInBatch();
+		workspaceMemberRepository.deleteAllInBatch();
+		workspaceRepository.deleteAllInBatch();
+		problemRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("풀이 기준으로 댓글 목록을 생성순으로 조회한다")
+	void findBySolutionId() {
+		// given
+		Fixture fixture = createFixture();
+		solutionCommentRepository.save(SolutionComment.create(fixture.solution, fixture.member, "첫 댓글"));
+		solutionCommentRepository.save(SolutionComment.create(fixture.solution, fixture.member, "둘째 댓글"));
+
+		// when
+		List<SolutionComment> result = solutionCommentRepository.findBySolutionId(fixture.solution.getId());
+
+		// then
+		assertThat(result)
+			.extracting("content")
+			.containsExactly("첫 댓글", "둘째 댓글");
+	}
+
+	@Test
+	@DisplayName("풀이별 댓글 수를 집계할 수 있다")
+	void countBySolutionIds() {
+		// given
+		Fixture fixture = createFixture();
+		Solution anotherSolution = solutionRepository.save(Solution.create(
+			fixture.workspaceProblem,
+			fixture.member,
+			101L,
+			"틀렸습니다",
+			"4 ms",
+			"2048 KB",
+			"Python 3",
+			"50 B",
+			null
+		));
+		solutionCommentRepository.save(SolutionComment.create(fixture.solution, fixture.member, "댓글 1"));
+		solutionCommentRepository.save(SolutionComment.create(fixture.solution, fixture.member, "댓글 2"));
+		solutionCommentRepository.save(SolutionComment.create(anotherSolution, fixture.member, "댓글 3"));
+
+		// when
+		List<Object[]> rows = solutionCommentRepository.countBySolutionIds(
+			List.of(fixture.solution.getId(), anotherSolution.getId())
+		);
+		Map<Long, Long> countMap = rows.stream()
+			.collect(Collectors.toMap(
+				row -> (Long)row[0],
+				row -> ((Number)row[1]).longValue()
+			));
+
+		// then
+		assertThat(countMap).containsEntry(fixture.solution.getId(), 2L);
+		assertThat(countMap).containsEntry(anotherSolution.getId(), 1L);
+	}
+
+	private Fixture createFixture() {
+		User user = userRepository.save(
+			User.createLocalUser(UUID.randomUUID() + "@example.com", Password.ofEncoded("pw"), "유저")
+		);
+		Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스-" + UUID.randomUUID(), "소개"));
+		WorkspaceMember member = workspaceMemberRepository.save(
+			WorkspaceMember.create(workspace, user, WorkspaceMemberRole.MEMBER)
+		);
+		Problem problem = problemRepository.save(Problem.create(
+			1000, "A+B", "Bronze V", "2 초", "128 MB", null, null, null, null
+		));
+		ProblemBox problemBox = problemBoxRepository.save(ProblemBox.create(workspace, "문제집", "설명"));
+		WorkspaceProblem workspaceProblem = workspaceProblemRepository.save(
+			WorkspaceProblem.create(problemBox, problem, null, null)
+		);
+		Solution solution = solutionRepository.save(Solution.create(
+			workspaceProblem,
+			member,
+			100L,
+			"맞았습니다!!",
+			"0 ms",
+			"2020 KB",
+			"Java 11",
+			"100 B",
+			null
+		));
+		return new Fixture(member, workspaceProblem, solution);
+	}
+
+	private record Fixture(
+		WorkspaceMember member,
+		WorkspaceProblem workspaceProblem,
+		Solution solution
+	) {
+	}
+}

--- a/src/test/java/com/ujax/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/user/UserRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
@@ -107,5 +108,39 @@ class UserRepositoryTest {
 		assertThat(savedUser.getId()).isNotNull();
 		assertThat(savedUser.getProvider()).isEqualTo(AuthProvider.LOCAL);
 		assertThat(savedUser.getPassword().getEncodedValue()).isEqualTo("password123!");
+	}
+
+	@Test
+	@DisplayName("여러 로컬 유저는 providerId가 null이어도 함께 저장할 수 있다")
+	void save_multipleLocalUsers() {
+		// given
+		User first = User.createLocalUser("local1@example.com", Password.ofEncoded("password123!"), "로컬유저1");
+		User second = User.createLocalUser("local2@example.com", Password.ofEncoded("password123!"), "로컬유저2");
+
+		// when
+		userRepository.saveAndFlush(first);
+		userRepository.saveAndFlush(second);
+
+		// then
+		assertThat(userRepository.count()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("같은 provider와 providerId 조합의 OAuth 유저는 중복 저장할 수 없다")
+	void save_duplicateOAuthIdentity() {
+		// given
+		userRepository.saveAndFlush(User.createOAuthUser(
+			"google1@example.com", "구글유저1", null,
+			AuthProvider.GOOGLE, "google-identity-123"
+		));
+
+		User duplicate = User.createOAuthUser(
+			"google2@example.com", "구글유저2", null,
+			AuthProvider.GOOGLE, "google-identity-123"
+		);
+
+		// when & then
+		assertThatThrownBy(() -> userRepository.saveAndFlush(duplicate))
+			.isInstanceOf(DataIntegrityViolationException.class);
 	}
 }

--- a/src/test/java/com/ujax/domain/webhook/WebhookAlertLogRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/webhook/WebhookAlertLogRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.ujax.domain.webhook;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class WebhookAlertLogRepositoryTest {
+
+	@Autowired
+	private WebhookAlertLogRepository webhookAlertLogRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		webhookAlertLogRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("workspace_problem_id 기준으로 로그를 생성순으로 조회한다")
+	void findAllByWorkspaceProblemIdOrderByCreatedAtAsc() {
+		// given
+		WebhookAlertLog first = webhookAlertLogRepository.saveAndFlush(WebhookAlertLog.create(
+			1L, 101L, 11L, WebhookAlertLogEventType.CREATED, null, WebhookAlertStatus.PENDING,
+			LocalDateTime.of(2026, 3, 27, 10, 0), null, 0, null, null, null, WebhookAlertLogActorType.USER, 1L
+		));
+		WebhookAlertLog second = webhookAlertLogRepository.saveAndFlush(WebhookAlertLog.create(
+			1L, 101L, 11L, WebhookAlertLogEventType.SCHEDULE_UPDATED, WebhookAlertStatus.PENDING, WebhookAlertStatus.PENDING,
+			LocalDateTime.of(2026, 3, 27, 11, 0), null, 0, null, null, null, WebhookAlertLogActorType.USER, 1L
+		));
+
+		jdbcTemplate.update(
+			"UPDATE webhook_alert_log SET created_at = ? WHERE webhook_alert_log_id = ?",
+			Timestamp.valueOf(LocalDateTime.of(2026, 3, 27, 9, 0)),
+			first.getId()
+		);
+		jdbcTemplate.update(
+			"UPDATE webhook_alert_log SET created_at = ? WHERE webhook_alert_log_id = ?",
+			Timestamp.valueOf(LocalDateTime.of(2026, 3, 27, 9, 5)),
+			second.getId()
+		);
+
+		// when
+		List<WebhookAlertLog> result = webhookAlertLogRepository.findAllByWorkspaceProblemIdOrderByCreatedAtAsc(101L);
+
+		// then
+		assertThat(result)
+			.extracting(WebhookAlertLog::getId)
+			.containsExactly(first.getId(), second.getId());
+	}
+
+}

--- a/src/test/java/com/ujax/domain/webhook/WebhookAlertRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/webhook/WebhookAlertRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.ujax.domain.webhook;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ujax.infrastructure.persistence.jpa.JpaAuditingConfig;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+class WebhookAlertRepositoryTest {
+
+	@Autowired
+	private WebhookAlertRepository webhookAlertRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		webhookAlertRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("PROCESSING 상태이면서 cutoff 이전에 갱신된 alert만 조회한다")
+	void findAllByStatusAndUpdatedAtBefore() {
+		// given
+		WebhookAlert stuckAlert = webhookAlertRepository.saveAndFlush(
+			WebhookAlert.create(101L, 11L, LocalDateTime.of(2026, 3, 27, 10, 0))
+		);
+		stuckAlert.markProcessing();
+		webhookAlertRepository.saveAndFlush(stuckAlert);
+
+		WebhookAlert freshAlert = webhookAlertRepository.saveAndFlush(
+			WebhookAlert.create(102L, 11L, LocalDateTime.of(2026, 3, 27, 11, 0))
+		);
+		freshAlert.markProcessing();
+		webhookAlertRepository.saveAndFlush(freshAlert);
+
+		WebhookAlert pendingAlert = webhookAlertRepository.saveAndFlush(
+			WebhookAlert.create(103L, 11L, LocalDateTime.of(2026, 3, 27, 12, 0))
+		);
+
+		LocalDateTime oldUpdatedAt = LocalDateTime.of(2026, 3, 27, 9, 0);
+		LocalDateTime cutoff = LocalDateTime.of(2026, 3, 27, 9, 30);
+		jdbcTemplate.update(
+			"UPDATE webhook_alert SET updated_at = ? WHERE webhook_alert_id = ?",
+			Timestamp.valueOf(oldUpdatedAt),
+			stuckAlert.getId()
+		);
+
+		// when
+		List<WebhookAlert> result = webhookAlertRepository.findAllByStatusAndUpdatedAtBefore(
+			WebhookAlertStatus.PROCESSING,
+			cutoff
+		);
+
+		// then
+		assertThat(result)
+			.extracting(WebhookAlert::getId)
+			.containsExactly(stuckAlert.getId());
+		assertThat(pendingAlert.getStatus()).isEqualTo(WebhookAlertStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("같은 workspaceProblemId의 alert는 하나만 생성된다")
+	void uniqueWorkspaceProblemId() {
+		// given
+		webhookAlertRepository.saveAndFlush(
+			WebhookAlert.create(201L, 21L, LocalDateTime.of(2026, 3, 27, 10, 0))
+		);
+
+		// when & then
+		assertThatThrownBy(() -> webhookAlertRepository.saveAndFlush(
+			WebhookAlert.create(201L, 21L, LocalDateTime.of(2026, 3, 27, 11, 0))
+		)).isInstanceOf(DataIntegrityViolationException.class);
+	}
+
+}

--- a/src/test/java/com/ujax/domain/workspace/WorkspaceJoinRequestRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/workspace/WorkspaceJoinRequestRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ujax.domain.user.Password;
@@ -66,4 +67,20 @@ class WorkspaceJoinRequestRepositoryTest {
 			.extracting("id")
 			.containsExactly(saved.getId());
 	}
+
+	@Test
+	@DisplayName("같은 워크스페이스와 유저의 가입 신청은 하나만 생성된다")
+	void uniqueWorkspaceAndUser() {
+		// given
+		Workspace workspace = workspaceRepository.save(Workspace.create("워크스페이스", "소개"));
+		User user = userRepository.save(
+			User.createLocalUser("join-request-unique@example.com", Password.ofEncoded("password"), "신청자")
+		);
+		workspaceJoinRequestRepository.saveAndFlush(WorkspaceJoinRequest.create(workspace, user));
+
+		// when & then
+		assertThatThrownBy(() -> workspaceJoinRequestRepository.saveAndFlush(WorkspaceJoinRequest.create(workspace, user)))
+			.isInstanceOf(DataIntegrityViolationException.class);
+	}
+
 }


### PR DESCRIPTION
# 관련 작업 / 이슈

> 관련된 이슈나 작업 번호를 링크해 주세요.

- 없음

---

## 내용 요약 (Description)
> 어떤 변경 혹은 추가를 했는지 간단히 정리해 주세요.

- 내용:
  - auth: `users(provider, provider_id)` 유니크를 추가해 OAuth 계정 식별 무결성을 보강했습니다.
  - workspace: `workspace_members(user_id)` 인덱스와 `workspace_join_requests(workspace_id, user_id)` 유니크/목록 인덱스를 정리했습니다.
  - content: `boards`, `board_comments`, `problem_box`, `workspace_problem`, `solution`, `solution_comments`의 목록/집계 조회 경로에 맞춰 인덱스를 추가했습니다.
  - webhook: 스케줄러 경로에 맞게 `webhook_alert(status, scheduled_at)`, `webhook_alert(status, updated_at)`, `webhook_alert_log(workspace_problem_id, created_at)` 중심으로 인덱스를 정리했습니다.

---

## 테스트
> 어떻게 테스트했는지 사진과 함께 적어 주세요.

---

## PR 체크리스트
> 아래 항목 중 해당되는 것만 체크해 주세요. (N/A면 비워둬도 됩니다.)

- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

> 외부 API, DB 스키마, 배치 스케줄 등에 영향이 있는지 표시해 주세요.

- [x] Yes (호환성 깨짐 있음)
- [ ] No

> Yes인 경우, 무엇이 어떻게 깨지는지, 배포/마이그레이션 시 주의사항을 남겨 주세요.

- 기존 `flyway_schema_history`를 유지한 DB와는 호환되지 않습니다.
- 이번 PR은 DB를 재생성하는 전제에서 `V1__baseline_schema.sql`을 기준으로 초기화해야 합니다.
- 새 baseline에는 신규 unique/index가 포함되어 있으므로 기존 데이터를 보존한 상태로 바로 적용하는 방식은 가정하지 않았습니다.

---

## 로그 / 스크린샷 (선택)
> 이 섹션에 변경 사항이 제대로 작동하는지 보여주는 사진을 첨부하세요.

- 없음

---

## 기타 정보 / 의존성 (선택)
> 이 PR과 함께 고려해야 할 사항, 후속 TODO 등을 적어 주세요.

- 관련 TODO: `application-local.yml`, `application-test.yml`의 `flyway + validate` 전환 검토
- 추후 리팩터링/성능 개선 포인트: 보류한 `refresh_tokens`, `workspace_problem deadline`, `board_likes/solution_likes` 인덱스 재검토
- 다른 모듈/서비스와의 의존성 또는 영향: 배치/로그인/워크스페이스/콘텐츠 조회 경로 전반의 DB 실행계획에 영향이 있습니다.
