### PR TITLE
[REFACTOR] 워크스페이스 검색 조회 분기 정리

### DIFF
--- a/src/main/java/com/ujax/application/workspace/WorkspaceService.java
+++ b/src/main/java/com/ujax/application/workspace/WorkspaceService.java
@@ -53,7 +53,9 @@ public class WorkspaceService {
 		validatePageable(page, size);
 		String normalizedName = name == null ? null : name.trim();
 		PageRequest pageable = PageRequest.of(page, size, WORKSPACE_DEFAULT_SORT);
-		Page<Workspace> workspaces = workspaceRepository.findByNameContainingOrAll(normalizedName, pageable);
+		Page<Workspace> workspaces = normalizedName == null || normalizedName.isBlank()
+			? workspaceRepository.findAll(pageable)
+			: workspaceRepository.findByNameContaining(normalizedName, pageable);
 		return PageResponse.of(
 			workspaces.getContent().stream().map(WorkspaceResponse::from).toList(),
 			workspaces.getNumber(),

--- a/src/main/java/com/ujax/domain/workspace/WorkspaceRepository.java
+++ b/src/main/java/com/ujax/domain/workspace/WorkspaceRepository.java
@@ -43,10 +43,4 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
 	boolean existsByName(String name);
 
 	Page<Workspace> findByNameContaining(String name, Pageable pageable);
-
-	@Query("""
-		SELECT w FROM Workspace w
-		WHERE (:name IS NULL OR :name = '' OR w.name LIKE CONCAT('%', :name, '%'))
-		""")
-	Page<Workspace> findByNameContainingOrAll(@Param("name") String name, Pageable pageable);
 }

--- a/src/test/java/com/ujax/application/workspace/WorkspaceServiceUnitTest.java
+++ b/src/test/java/com/ujax/application/workspace/WorkspaceServiceUnitTest.java
@@ -1,0 +1,126 @@
+package com.ujax.application.workspace;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ujax.domain.user.UserRepository;
+import com.ujax.domain.workspace.Workspace;
+import com.ujax.domain.workspace.WorkspaceMemberRepository;
+import com.ujax.domain.workspace.WorkspaceRepository;
+import com.ujax.global.exception.ErrorCode;
+import com.ujax.global.exception.common.BadRequestException;
+import com.ujax.infrastructure.external.s3.S3StorageService;
+
+@ExtendWith(MockitoExtension.class)
+class WorkspaceServiceUnitTest {
+
+	@Mock
+	private WorkspaceRepository workspaceRepository;
+
+	@Mock
+	private WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private S3StorageService s3StorageService;
+
+	@InjectMocks
+	private WorkspaceService workspaceService;
+
+	@Test
+	@DisplayName("listWorkspaces: 검색어가 없으면 전체 조회 경로를 사용한다")
+	void listWorkspacesUsesFindAllWhenNameIsNull() {
+		// given
+		Workspace workspace = workspace(1L, "워크스페이스");
+		PageRequest pageable = PageRequest.of(0, 20, defaultSort());
+		given(workspaceRepository.findAll(any(Pageable.class)))
+			.willReturn(new PageImpl<>(List.of(workspace), pageable, 1));
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+		// when
+		var response = workspaceService.listWorkspaces(null, 0, 20);
+
+		// then
+		then(workspaceRepository).should().findAll(pageableCaptor.capture());
+		then(workspaceRepository).should(never()).findByNameContaining(anyString(), any(Pageable.class));
+		assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
+		assertThat(response.getContent()).extracting("id", "name")
+			.containsExactly(tuple(1L, "워크스페이스"));
+	}
+
+	@Test
+	@DisplayName("listWorkspaces: 공백 검색어면 전체 조회 경로를 사용한다")
+	void listWorkspacesUsesFindAllWhenNameIsBlank() {
+		// given
+		PageRequest pageable = PageRequest.of(0, 20, defaultSort());
+		given(workspaceRepository.findAll(any(Pageable.class)))
+			.willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+		// when
+		workspaceService.listWorkspaces("   ", 0, 20);
+
+		// then
+		then(workspaceRepository).should().findAll(pageable);
+		then(workspaceRepository).should(never()).findByNameContaining(anyString(), any(Pageable.class));
+	}
+
+	@Test
+	@DisplayName("listWorkspaces: 검색어가 있으면 이름 검색 경로를 사용한다")
+	void listWorkspacesUsesNameSearchWhenNameExists() {
+		// given
+		Workspace workspace = workspace(2L, "테스트 공간");
+		PageRequest pageable = PageRequest.of(0, 20, defaultSort());
+		given(workspaceRepository.findByNameContaining(eq("테스트"), any(Pageable.class)))
+			.willReturn(new PageImpl<>(List.of(workspace), pageable, 1));
+
+		// when
+		var response = workspaceService.listWorkspaces("  테스트  ", 0, 20);
+
+		// then
+		then(workspaceRepository).should().findByNameContaining("테스트", pageable);
+		then(workspaceRepository).should(never()).findAll(any(Pageable.class));
+		assertThat(response.getContent()).extracting("id", "name")
+			.containsExactly(tuple(2L, "테스트 공간"));
+	}
+
+	@Test
+	@DisplayName("listWorkspaces: 페이지 값이 잘못되면 조회하지 않고 예외가 발생한다")
+	void listWorkspacesThrowsBeforeRepositoryCallWhenPageableInvalid() {
+		// when & then
+		assertThatThrownBy(() -> workspaceService.listWorkspaces(null, -1, 0))
+			.isInstanceOf(BadRequestException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PARAMETER);
+		then(workspaceRepository).shouldHaveNoInteractions();
+	}
+
+	private Workspace workspace(Long id, String name) {
+		Workspace workspace = Workspace.create(name, "소개");
+		ReflectionTestUtils.setField(workspace, "id", id);
+		return workspace;
+	}
+
+	private Sort defaultSort() {
+		return Sort.by(
+			Sort.Order.desc("createdAt"),
+			Sort.Order.desc("id")
+		);
+	}
+}

--- a/src/test/java/com/ujax/domain/workspace/WorkspaceRepositoryTest.java
+++ b/src/test/java/com/ujax/domain/workspace/WorkspaceRepositoryTest.java
@@ -49,14 +49,13 @@ class WorkspaceRepositoryTest {
 
 	@Test
 	@DisplayName("검색어가 없으면 최신순으로 전체 워크스페이스를 조회한다")
-	void findByNameContainingOrAllWithoutName() {
+	void findAllLatestOrder() {
 		// given
 		Workspace older = workspaceRepository.save(Workspace.create("오래된 공간", "소개"));
 		Workspace newer = workspaceRepository.save(Workspace.create("새 공간", "소개"));
 
 		// when
-		Page<Workspace> result = workspaceRepository.findByNameContainingOrAll(
-			null,
+		Page<Workspace> result = workspaceRepository.findAll(
 			PageRequest.of(0, 10, org.springframework.data.domain.Sort.by(
 				org.springframework.data.domain.Sort.Order.desc("createdAt"),
 				org.springframework.data.domain.Sort.Order.desc("id")


### PR DESCRIPTION
# 관련 작업 / 이슈

- #63

---

## 내용 요약 (Description)
- 내용:
  `WorkspaceService`에서 검색어 null/blank 여부를 분기해 전체 조회(`findAll(pageable)`)와 이름 검색 조회(`findByNameContaining(...)`) 경로를 분리했습니다.
  `WorkspaceRepository`의 `findByNameContainingOrAll(...)` 메서드를 제거했습니다.
  `WorkspaceServiceUnitTest`를 추가하고 `WorkspaceRepositoryTest`를 새 분기 구조 기준으로 정리했습니다.
  기존 워크스페이스 탐색 API의 응답 구조와 정렬 정책은 유지됩니다.

---

## 테스트
- 테스트 시나리오 설명:
  `./gradlew verify`
  `./gradlew test --tests com.ujax.application.workspace.WorkspaceServiceUnitTest --tests com.ujax.application.workspace.WorkspaceServiceTest --tests com.ujax.domain.workspace.WorkspaceRepositoryTest --tests com.ujax.infrastructure.web.api.workspace.WorkspaceControllerTest`

---

## PR 체크리스트
- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

- [ ] Yes (호환성 깨짐 있음)
- [x] No

---

## 로그 / 스크린샷 (선택)
- 없음

---

## 기타 정보 / 의존성 (선택)
- 관련 TODO: 없음
- 추후 리팩터링/성능 개선 포인트: 필요 시 `findByNameContaining`의 검색 성능은 별도 작업으로 다룰 수 있습니다.
- 다른 모듈/서비스와의 의존성 또는 영향: 없음
