### PR TITLE
[REFACTOR] Webhook 전용 HTTP client 분리 및 timeout 정책 정리

### DIFF
--- a/src/main/java/com/ujax/application/submission/SubmissionService.java
+++ b/src/main/java/com/ujax/application/submission/SubmissionService.java
@@ -8,8 +8,8 @@ import com.ujax.global.exception.common.Judge0Exception;
 import com.ujax.infrastructure.external.judge0.dto.Judge0RawResponse;
 import com.ujax.infrastructure.web.submission.dto.SubmissionRequest;
 import com.ujax.infrastructure.web.submission.dto.SubmissionResultResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.*;
@@ -21,7 +21,6 @@ import java.util.*;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class SubmissionService {
 
     private final RestTemplate restTemplate;
@@ -30,6 +29,16 @@ public class SubmissionService {
 
     @Value("${judge0.api.url}")
     private String judge0Url;
+
+    public SubmissionService(
+        @Qualifier("judge0RestTemplate") RestTemplate restTemplate,
+        StringRedisTemplate redisTemplate,
+        ObjectMapper objectMapper
+    ) {
+        this.restTemplate = restTemplate;
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
 
     private record TestCaseMetadata(String input, String expected) {
     }

--- a/src/main/java/com/ujax/infrastructure/external/judge0/Judge0Config.java
+++ b/src/main/java/com/ujax/infrastructure/external/judge0/Judge0Config.java
@@ -1,14 +1,14 @@
-package com.ujax.infrastructure.network;
+package com.ujax.infrastructure.external.judge0;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class NetworkConfig {
+public class Judge0Config {
 
-    @Bean
-    public RestTemplate restTemplate() {
+    @Bean("judge0RestTemplate")
+    public RestTemplate judge0RestTemplate() {
         return new RestTemplate();
     }
 }

--- a/src/main/java/com/ujax/infrastructure/external/webhook/RestTemplateWebhookSender.java
+++ b/src/main/java/com/ujax/infrastructure/external/webhook/RestTemplateWebhookSender.java
@@ -9,20 +9,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import com.ujax.application.webhook.WebhookAlertMessage;
 import com.ujax.application.webhook.WebhookSender;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class RestTemplateWebhookSender implements WebhookSender {
 
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("MM월 dd일 HH:mm");
@@ -32,6 +29,14 @@ public class RestTemplateWebhookSender implements WebhookSender {
 
 	private final RestTemplate restTemplate;
 	private final ObjectMapper objectMapper;
+
+	public RestTemplateWebhookSender(
+		@Qualifier("webhookRestTemplate") RestTemplate restTemplate,
+		ObjectMapper objectMapper
+	) {
+		this.restTemplate = restTemplate;
+		this.objectMapper = objectMapper;
+	}
 
 	@Override
 	public void send(String hookUrl, WebhookAlertMessage message) {

--- a/src/main/java/com/ujax/infrastructure/external/webhook/WebhookConfig.java
+++ b/src/main/java/com/ujax/infrastructure/external/webhook/WebhookConfig.java
@@ -1,0 +1,18 @@
+package com.ujax.infrastructure.external.webhook;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebhookConfig {
+
+    @Bean("webhookRestTemplate")
+    public RestTemplate webhookRestTemplate(WebhookHttpProperties webhookHttpProperties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(webhookHttpProperties.connectTimeoutMillis());
+        requestFactory.setReadTimeout(webhookHttpProperties.readTimeoutMillis());
+        return new RestTemplate(requestFactory);
+    }
+}

--- a/src/main/java/com/ujax/infrastructure/external/webhook/WebhookHttpProperties.java
+++ b/src/main/java/com/ujax/infrastructure/external/webhook/WebhookHttpProperties.java
@@ -1,0 +1,14 @@
+package com.ujax.infrastructure.external.webhook;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.webhook-alert.http")
+public record WebhookHttpProperties(
+    @DefaultValue("1000") @Min(1) int connectTimeoutMillis,
+    @DefaultValue("2000") @Min(1) int readTimeoutMillis
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,9 @@ app:
       enabled: ${WEBHOOK_ALERT_SCHEDULER_ENABLED:true}
       fixed-delay-millis: ${WEBHOOK_ALERT_SCHEDULER_FIXED_DELAY_MILLIS:60000}
       batch-size: ${WEBHOOK_ALERT_SCHEDULER_BATCH_SIZE:100}
+    http:
+      connect-timeout-millis: ${WEBHOOK_ALERT_CONNECT_TIMEOUT_MILLIS:1000}
+      read-timeout-millis: ${WEBHOOK_ALERT_READ_TIMEOUT_MILLIS:2000}
     delivery:
       retry-delay-minutes: ${WEBHOOK_ALERT_RETRY_DELAY_MINUTES:1}
       stuck-processing-minutes: ${WEBHOOK_ALERT_STUCK_PROCESSING_MINUTES:10}

--- a/src/test/java/com/ujax/infrastructure/external/judge0/Judge0ConfigTest.java
+++ b/src/test/java/com/ujax/infrastructure/external/judge0/Judge0ConfigTest.java
@@ -1,0 +1,24 @@
+package com.ujax.infrastructure.external.judge0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+class Judge0ConfigTest {
+
+    private final Judge0Config judge0Config = new Judge0Config();
+
+    @Test
+    @DisplayName("Judge0 전용 RestTemplate을 생성한다")
+    void createJudge0RestTemplate() {
+        // when
+        RestTemplate restTemplate = judge0Config.judge0RestTemplate();
+
+        // then
+        assertThat(restTemplate).isNotNull();
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(SimpleClientHttpRequestFactory.class);
+    }
+}

--- a/src/test/java/com/ujax/infrastructure/external/webhook/WebhookConfigTest.java
+++ b/src/test/java/com/ujax/infrastructure/external/webhook/WebhookConfigTest.java
@@ -1,0 +1,31 @@
+package com.ujax.infrastructure.external.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+class WebhookConfigTest {
+
+    private final WebhookConfig webhookConfig = new WebhookConfig();
+
+    @Test
+    @DisplayName("Webhook 전용 RestTemplate에 timeout 설정을 반영한다")
+    void createWebhookRestTemplate() {
+        // given
+        WebhookHttpProperties webhookHttpProperties = new WebhookHttpProperties(1500, 2500);
+
+        // when
+        RestTemplate restTemplate = webhookConfig.webhookRestTemplate(webhookHttpProperties);
+
+        // then
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(SimpleClientHttpRequestFactory.class);
+
+        SimpleClientHttpRequestFactory requestFactory = (SimpleClientHttpRequestFactory) restTemplate.getRequestFactory();
+        assertThat(ReflectionTestUtils.getField(requestFactory, "connectTimeout")).isEqualTo(1500);
+        assertThat(ReflectionTestUtils.getField(requestFactory, "readTimeout")).isEqualTo(2500);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -51,6 +51,9 @@ app:
       enabled: ${WEBHOOK_ALERT_SCHEDULER_ENABLED:false}
       fixed-delay-millis: ${WEBHOOK_ALERT_SCHEDULER_FIXED_DELAY_MILLIS:60000}
       batch-size: ${WEBHOOK_ALERT_SCHEDULER_BATCH_SIZE:100}
+    http:
+      connect-timeout-millis: ${WEBHOOK_ALERT_CONNECT_TIMEOUT_MILLIS:1000}
+      read-timeout-millis: ${WEBHOOK_ALERT_READ_TIMEOUT_MILLIS:2000}
     delivery:
       retry-delay-minutes: ${WEBHOOK_ALERT_RETRY_DELAY_MINUTES:1}
       stuck-processing-minutes: ${WEBHOOK_ALERT_STUCK_PROCESSING_MINUTES:10}


### PR DESCRIPTION
# 관련 작업 / 이슈

- Resolved: #89
- Parent: #88

---

## 내용 요약 (Description)
- Judge0와 Webhook이 공유하던 `RestTemplate` wiring을 분리했습니다.
- Judge0/Webhook 외부 연동 설정을 각 패키지(`external/judge0`, `external/webhook`)로 이동했습니다.
- Webhook 전용 timeout 설정(`app.webhook-alert.http.*`)을 추가했습니다.
- `SubmissionService`, `RestTemplateWebhookSender`가 각각 명시적인 전용 bean을 주입받도록 변경했습니다.

- 내용:
  - `judge0RestTemplate`, `webhookRestTemplate` 분리
  - `WebhookConfig`, `WebhookHttpProperties`, `Judge0Config` 추가
  - 관련 config 테스트 추가
  - `application.yml`, `application-test.yml`에 Webhook timeout 설정 추가

---

## 테스트
- 테스트 시나리오 설명:
  - `./gradlew compileJava compileTestJava`
  - 대상 테스트 직접 실행
    - `com.ujax.infrastructure.external.judge0.Judge0ConfigTest`
    - `com.ujax.infrastructure.external.webhook.WebhookConfigTest`
    - `com.ujax.infrastructure.external.webhook.RestTemplateWebhookSenderTest`
    - `com.ujax.application.submission.SubmissionServiceTest`
  - pre-push hook에서 `./gradlew verify` 자동 실행 및 통과 후 push 완료

---

## PR 체크리스트
- [x] 관련 이슈(작업 항목)를 PR 설명에 연결했다.
- [x] `./gradlew verify` 를 로컬에서 실행해 모두 통과함.
- [x] 불필요한 로그, 디버깅 코드, 주석을 제거했다.
- [x] 이 변경과 충돌할 수 있는 다른 PR이나 변경 사항이 없는지 확인했다.

---

## Breaking Change 여부

- [ ] Yes (호환성 깨짐 있음)
- [x] No

---

## 로그 / 스크린샷 (선택)
- 없음

---

## 기타 정보 / 의존성 (선택)
- 관련 TODO:
  - `SubmissionService`에서 Judge0 external client 추상화 분리 (#94)
- 추후 리팩터링/성능 개선 포인트:
  - Webhook sender formatter / transport 분리 (#90)
  - Webhook delivery 계층 분리 및 structured log 전환 (#87)
- 다른 모듈/서비스와의 의존성 또는 영향:
  - 없음. API/DB 스키마 변경 없이 wiring/config 범위만 조정함.
